### PR TITLE
Apply NaNDA brand: colors, font, larger table cells, drop study ID col

### DIFF
--- a/build_dashboard.py
+++ b/build_dashboard.py
@@ -231,8 +231,7 @@ def main() -> None:
         out = []
         for row in curated_rows:
             out.append(
-                "<tr>"
-                f"<td class=\"num\">{row['study_id']}</td>"
+                f"<tr data-study-id=\"{row['study_id']}\">"
                 f"<td class=\"title-cell\">{title_link(row)}</td>"
                 f"<td class=\"num\" data-sort=\"{row['total']}\">{row['total']:,}</td>"
                 f"{delta_cell(row)}"
@@ -246,8 +245,7 @@ def main() -> None:
         out = []
         for row in self_rows:
             out.append(
-                "<tr>"
-                f"<td class=\"num\">{row['study_id']}</td>"
+                f"<tr data-study-id=\"{row['study_id']}\">"
                 f"<td class=\"title-cell\">{title_link(row)}</td>"
                 f"<td class=\"num\" data-sort=\"{row['total']}\">{row['total']:,}</td>"
                 f"{num_cell(row['views'])}"
@@ -307,25 +305,32 @@ def main() -> None:
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{html.escape(page_title)}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&display=swap">
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 <style>
 :root {{
-  --bg: #f4f6f8;
-  --surface: #ffffff;
-  --text: #1a1a1a;
+  /* NaNDA brand */
+  --nanda-blue-dark: #01528a;
+  --nanda-blue-light: #1499d6;
+  --nanda-white: #ffffff;
+  /* Semantic aliases */
+  --bg: var(--nanda-white);
+  --surface: var(--nanda-white);
+  --text: var(--nanda-blue-dark);
   --muted: #555555;
+  --accent: var(--nanda-blue-light);
   --border: #d0d7de;
-  --brand: #01528a;
-  --brand-deep: #013d68;
   --pos: #1a7f37;
   --neg: #b42318;
-  --row-hover: #f0f4f8;
+  --row-hover: #eaf4fb;
   --focus: #ff8a00;
 }}
 * {{ box-sizing: border-box; }}
 html {{ scroll-behavior: smooth; overflow-x: hidden; }}
 body {{
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-family: 'Atkinson Hyperlegible', system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   margin: 0;
   background: var(--bg);
   color: var(--text);
@@ -342,7 +347,7 @@ body {{
 }}
 .skip-link:focus {{
   position: static; width: auto; height: auto; padding: 0.5rem 1rem;
-  background: var(--brand); color: #fff; text-decoration: none; display: inline-block;
+  background: var(--nanda-blue-dark); color: #fff; text-decoration: none; display: inline-block;
   margin: 0.5rem 0;
 }}
 .visually-hidden {{
@@ -351,8 +356,8 @@ body {{
   clip: rect(0,0,0,0); white-space: nowrap; border: 0;
 }}
 
-a {{ color: var(--brand); }}
-a:hover {{ color: var(--brand-deep); }}
+a {{ color: var(--nanda-blue-dark); text-decoration: underline; text-underline-offset: 2px; }}
+a:hover {{ color: var(--nanda-blue-dark); text-decoration-thickness: 2px; }}
 a:focus-visible, button:focus-visible, input:focus-visible, summary:focus-visible {{
   outline: 3px solid var(--focus);
   outline-offset: 2px;
@@ -378,33 +383,34 @@ header {{
   width: auto;
   display: block;
 }}
-.brand h1 {{ margin: 0; font-size: clamp(1.4rem, 2.5vw, 1.8rem); line-height: 1.2; }}
+.brand h1 {{ margin: 0; font-size: clamp(1.4rem, 2.5vw, 1.8rem); line-height: 1.2; color: var(--nanda-blue-dark); }}
 .tagline {{ margin: 0.25rem 0 0; color: var(--muted); font-size: 0.95rem; max-width: 60ch; }}
 .updated {{ margin: 0; color: var(--muted); font-size: 0.9rem; }}
-.updated time {{ font-weight: 600; color: var(--text); }}
+.updated time {{ font-weight: 700; color: var(--nanda-blue-dark); }}
 
 section {{
   background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 8px;
   padding: 1.5rem;
   margin-bottom: 1.5rem;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
 }}
 section h2 {{
   margin: 0 0 1rem;
   font-size: 1.15rem;
-  color: var(--text);
+  color: var(--nanda-blue-dark);
+  font-weight: 700;
 }}
 section .definition {{
   margin: 0 0 1.25rem;
   padding: 0.85rem 1rem;
-  background: #eef4fa;
-  border-left: 4px solid var(--brand);
+  background: #eaf4fb;
+  border-left: 4px solid var(--nanda-blue-dark);
   border-radius: 4px;
   font-size: 0.92rem;
   color: var(--text);
 }}
-.definition strong {{ color: var(--brand-deep); }}
+.definition strong {{ color: var(--nanda-blue-dark); font-weight: 700; }}
 
 /* KPI cards */
 .kpis {{
@@ -418,22 +424,22 @@ section .definition {{
 }}
 .kpi {{
   background: var(--surface);
+  border: 1px solid var(--border);
   padding: 1.25rem 1.5rem;
   border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
 }}
 .kpi dl {{ margin: 0; }}
 .kpi dt {{
   margin: 0;
   color: var(--muted);
   font-size: 0.9rem;
-  font-weight: 500;
+  font-weight: 700;
 }}
 .kpi-value {{
   margin: 0.35rem 0 0;
   font-size: 2rem;
   font-weight: 700;
-  color: var(--text);
+  color: var(--nanda-blue-dark);
   font-variant-numeric: tabular-nums;
   line-height: 1.1;
 }}
@@ -464,8 +470,9 @@ section .definition {{
   margin-bottom: 0.75rem;
 }}
 .filter-row label {{
-  font-weight: 600;
-  font-size: 0.9rem;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--nanda-blue-dark);
 }}
 .filter-row input[type="search"] {{
   flex: 1 1 220px;
@@ -478,7 +485,7 @@ section .definition {{
   color: var(--text);
 }}
 .filter-row input[type="search"]:focus-visible {{
-  border-color: var(--brand);
+  border-color: var(--nanda-blue-dark);
 }}
 .filter-count {{
   margin: 0;
@@ -490,31 +497,34 @@ section .definition {{
 .table-scroll {{ overflow-x: auto; }}
 table.studies-table {{
   width: 100%;
-  min-width: 640px;
+  min-width: 720px;
   border-collapse: collapse;
-  font-size: 0.9rem;
+  table-layout: fixed;
 }}
 table.studies-table th,
 table.studies-table td {{
   text-align: left;
-  padding: 0.6rem 0.75rem;
+  padding: 0.65rem 0.85rem;
   border-bottom: 1px solid #e6e8eb;
   vertical-align: top;
 }}
-table.studies-table th {{
-  background: #f0f3f6;
-  font-weight: 600;
+table.studies-table tbody td {{
+  font-size: 1rem;
   color: var(--text);
+}}
+table.studies-table th {{
+  background: #eef4fa;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--nanda-blue-dark);
 }}
 table.studies-table th.num,
 table.studies-table td.num {{
   text-align: right;
   font-variant-numeric: tabular-nums;
 }}
-table.studies-table {{ table-layout: fixed; }}
-table.studies-table col.col-id {{ width: 5.5rem; }}
-table.studies-table col.col-num {{ width: 7.5rem; }}
-table.studies-table col.col-num-narrow {{ width: 6rem; }}
+table.studies-table col.col-num {{ width: 8.5rem; }}
+table.studies-table col.col-num-narrow {{ width: 7rem; }}
 table.studies-table .title-cell {{
   white-space: normal;
   overflow-wrap: anywhere;
@@ -537,7 +547,7 @@ button.sort-btn {{
   padding: 0;
   margin: 0;
   font: inherit;
-  font-weight: 600;
+  font-weight: 700;
   color: inherit;
   cursor: pointer;
   text-align: inherit;
@@ -549,10 +559,10 @@ button.sort-btn {{
 table.studies-table th.num button.sort-btn {{
   justify-content: flex-end;
 }}
-button.sort-btn:hover {{ color: var(--brand-deep); }}
-th[aria-sort="ascending"] button.sort-btn::after {{ content: "▲"; font-size: 0.7em; color: var(--brand); }}
-th[aria-sort="descending"] button.sort-btn::after {{ content: "▼"; font-size: 0.7em; color: var(--brand); }}
-th[aria-sort="none"] button.sort-btn::after {{ content: "↕"; font-size: 0.75em; color: var(--muted); opacity: 0.6; }}
+button.sort-btn:hover {{ text-decoration: underline; text-underline-offset: 3px; }}
+th[aria-sort="ascending"] button.sort-btn::after {{ content: "▲"; font-size: 0.75em; color: var(--accent); }}
+th[aria-sort="descending"] button.sort-btn::after {{ content: "▼"; font-size: 0.75em; color: var(--accent); }}
+th[aria-sort="none"] button.sort-btn::after {{ content: "↕"; font-size: 0.8em; color: var(--muted); opacity: 0.6; }}
 
 .row-hidden {{ display: none; }}
 
@@ -566,12 +576,12 @@ details {{
   border: 1px solid var(--border);
   border-radius: 4px;
   padding: 0.5rem 0.85rem;
-  background: #fafbfc;
+  background: var(--nanda-white);
 }}
 details > summary {{
   cursor: pointer;
-  font-weight: 600;
-  color: var(--brand-deep);
+  font-weight: 700;
+  color: var(--nanda-blue-dark);
 }}
 details[open] > summary {{ margin-bottom: 0.5rem; }}
 details p {{ margin: 0.5rem 0 0; }}
@@ -591,7 +601,7 @@ footer nav ul {{
   flex-wrap: wrap;
   gap: 0.5rem 1.5rem;
 }}
-footer nav a {{ font-weight: 500; }}
+footer nav a {{ font-weight: 700; }}
 footer p {{ margin: 0; }}
 
 @media (max-width: 600px) {{
@@ -672,7 +682,6 @@ footer p {{ margin: 0; }}
   <table id="curated-table" class="studies-table" aria-describedby="curated-def">
     <caption class="visually-hidden">Curated NaNDA datasets, sortable by column.</caption>
     <colgroup>
-      <col class="col-id">
       <col>
       <col class="col-num">
       <col class="col-num">
@@ -681,7 +690,6 @@ footer p {{ margin: 0; }}
     </colgroup>
     <thead>
       <tr>
-        <th scope="col" class="num" aria-sort="none"><button type="button" class="sort-btn" data-key="study_id" data-type="num">Study ID</button></th>
         <th scope="col" aria-sort="none"><button type="button" class="sort-btn" data-key="title" data-type="text">Title</button></th>
         <th scope="col" class="num" aria-sort="descending"><button type="button" class="sort-btn" data-key="total" data-type="num">Total downloads</button></th>
         <th scope="col" class="num" aria-sort="none"><button type="button" class="sort-btn" data-key="delta" data-type="num">Change this month</button></th>
@@ -709,7 +717,6 @@ footer p {{ margin: 0; }}
   <table id="self-table" class="studies-table" aria-describedby="self-def">
     <caption class="visually-hidden">Self-published NaNDA datasets, sortable by column.</caption>
     <colgroup>
-      <col class="col-id">
       <col>
       <col class="col-num">
       <col class="col-num">
@@ -717,7 +724,6 @@ footer p {{ margin: 0; }}
     </colgroup>
     <thead>
       <tr>
-        <th scope="col" class="num" aria-sort="none"><button type="button" class="sort-btn" data-key="study_id" data-type="num">Study ID</button></th>
         <th scope="col" aria-sort="none"><button type="button" class="sort-btn" data-key="title" data-type="text">Title</button></th>
         <th scope="col" class="num" aria-sort="descending"><button type="button" class="sort-btn" data-key="total" data-type="num">Total downloads</button></th>
         <th scope="col" class="num" aria-sort="none"><button type="button" class="sort-btn" data-key="views" data-type="num">Total views</button></th>
@@ -767,11 +773,13 @@ new Chart(document.getElementById("ts-chart"), {{
     datasets: [{{
       label: "Downloads",
       data: tsValues,
-      borderColor: "#01528a",
-      backgroundColor: "rgba(1, 82, 138, 0.12)",
+      borderColor: "#1499d6",
+      backgroundColor: "rgba(20, 153, 214, 0.15)",
+      borderWidth: 2,
       fill: true,
       tension: 0.25,
       pointRadius: 2,
+      pointBackgroundColor: "#01528a",
     }}],
   }},
   options: {{
@@ -788,11 +796,13 @@ new Chart(document.getElementById("ts-chart"), {{
     scales: {{
       y: {{
         beginAtZero: true,
-        ticks: {{ callback: v => v.toLocaleString() }},
-        title: {{ display: true, text: "Downloads per month", color: "#555555", font: {{ size: 12 }} }},
+        ticks: {{ callback: v => v.toLocaleString(), color: "#01528a" }},
+        title: {{ display: true, text: "Downloads per month", color: "#01528a", font: {{ size: 13, weight: "700" }} }},
+        grid: {{ color: "rgba(1, 82, 138, 0.08)" }},
       }},
       x: {{
-        ticks: {{ maxRotation: 45, autoSkip: true, maxTicksLimit: 16 }},
+        ticks: {{ maxRotation: 45, autoSkip: true, maxTicksLimit: 16, color: "#01528a" }},
+        grid: {{ color: "rgba(1, 82, 138, 0.08)" }},
       }},
     }},
   }},
@@ -857,8 +867,8 @@ new Chart(document.getElementById("ts-chart"), {{
       const q = input.value.trim().toLowerCase();
       let visible = 0;
       Array.from(table.tBodies[0].rows).forEach(function(row) {{
-        const id = row.cells[0].textContent.toLowerCase();
-        const title = row.cells[1].textContent.toLowerCase();
+        const id = (row.dataset.studyId || "").toLowerCase();
+        const title = row.cells[0].textContent.toLowerCase();
         const match = q === "" || id.includes(q) || title.includes(q);
         row.classList.toggle("row-hidden", !match);
         if (match) visible++;

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,25 +4,32 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>NaNDA Usage Dashboard — May 1, 2026</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&display=swap">
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 <style>
 :root {
-  --bg: #f4f6f8;
-  --surface: #ffffff;
-  --text: #1a1a1a;
+  /* NaNDA brand */
+  --nanda-blue-dark: #01528a;
+  --nanda-blue-light: #1499d6;
+  --nanda-white: #ffffff;
+  /* Semantic aliases */
+  --bg: var(--nanda-white);
+  --surface: var(--nanda-white);
+  --text: var(--nanda-blue-dark);
   --muted: #555555;
+  --accent: var(--nanda-blue-light);
   --border: #d0d7de;
-  --brand: #01528a;
-  --brand-deep: #013d68;
   --pos: #1a7f37;
   --neg: #b42318;
-  --row-hover: #f0f4f8;
+  --row-hover: #eaf4fb;
   --focus: #ff8a00;
 }
 * { box-sizing: border-box; }
 html { scroll-behavior: smooth; overflow-x: hidden; }
 body {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-family: 'Atkinson Hyperlegible', system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   margin: 0;
   background: var(--bg);
   color: var(--text);
@@ -39,7 +46,7 @@ body {
 }
 .skip-link:focus {
   position: static; width: auto; height: auto; padding: 0.5rem 1rem;
-  background: var(--brand); color: #fff; text-decoration: none; display: inline-block;
+  background: var(--nanda-blue-dark); color: #fff; text-decoration: none; display: inline-block;
   margin: 0.5rem 0;
 }
 .visually-hidden {
@@ -48,8 +55,8 @@ body {
   clip: rect(0,0,0,0); white-space: nowrap; border: 0;
 }
 
-a { color: var(--brand); }
-a:hover { color: var(--brand-deep); }
+a { color: var(--nanda-blue-dark); text-decoration: underline; text-underline-offset: 2px; }
+a:hover { color: var(--nanda-blue-dark); text-decoration-thickness: 2px; }
 a:focus-visible, button:focus-visible, input:focus-visible, summary:focus-visible {
   outline: 3px solid var(--focus);
   outline-offset: 2px;
@@ -75,33 +82,34 @@ header {
   width: auto;
   display: block;
 }
-.brand h1 { margin: 0; font-size: clamp(1.4rem, 2.5vw, 1.8rem); line-height: 1.2; }
+.brand h1 { margin: 0; font-size: clamp(1.4rem, 2.5vw, 1.8rem); line-height: 1.2; color: var(--nanda-blue-dark); }
 .tagline { margin: 0.25rem 0 0; color: var(--muted); font-size: 0.95rem; max-width: 60ch; }
 .updated { margin: 0; color: var(--muted); font-size: 0.9rem; }
-.updated time { font-weight: 600; color: var(--text); }
+.updated time { font-weight: 700; color: var(--nanda-blue-dark); }
 
 section {
   background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 8px;
   padding: 1.5rem;
   margin-bottom: 1.5rem;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
 }
 section h2 {
   margin: 0 0 1rem;
   font-size: 1.15rem;
-  color: var(--text);
+  color: var(--nanda-blue-dark);
+  font-weight: 700;
 }
 section .definition {
   margin: 0 0 1.25rem;
   padding: 0.85rem 1rem;
-  background: #eef4fa;
-  border-left: 4px solid var(--brand);
+  background: #eaf4fb;
+  border-left: 4px solid var(--nanda-blue-dark);
   border-radius: 4px;
   font-size: 0.92rem;
   color: var(--text);
 }
-.definition strong { color: var(--brand-deep); }
+.definition strong { color: var(--nanda-blue-dark); font-weight: 700; }
 
 /* KPI cards */
 .kpis {
@@ -115,22 +123,22 @@ section .definition {
 }
 .kpi {
   background: var(--surface);
+  border: 1px solid var(--border);
   padding: 1.25rem 1.5rem;
   border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
 }
 .kpi dl { margin: 0; }
 .kpi dt {
   margin: 0;
   color: var(--muted);
   font-size: 0.9rem;
-  font-weight: 500;
+  font-weight: 700;
 }
 .kpi-value {
   margin: 0.35rem 0 0;
   font-size: 2rem;
   font-weight: 700;
-  color: var(--text);
+  color: var(--nanda-blue-dark);
   font-variant-numeric: tabular-nums;
   line-height: 1.1;
 }
@@ -161,8 +169,9 @@ section .definition {
   margin-bottom: 0.75rem;
 }
 .filter-row label {
-  font-weight: 600;
-  font-size: 0.9rem;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--nanda-blue-dark);
 }
 .filter-row input[type="search"] {
   flex: 1 1 220px;
@@ -175,7 +184,7 @@ section .definition {
   color: var(--text);
 }
 .filter-row input[type="search"]:focus-visible {
-  border-color: var(--brand);
+  border-color: var(--nanda-blue-dark);
 }
 .filter-count {
   margin: 0;
@@ -187,31 +196,34 @@ section .definition {
 .table-scroll { overflow-x: auto; }
 table.studies-table {
   width: 100%;
-  min-width: 640px;
+  min-width: 720px;
   border-collapse: collapse;
-  font-size: 0.9rem;
+  table-layout: fixed;
 }
 table.studies-table th,
 table.studies-table td {
   text-align: left;
-  padding: 0.6rem 0.75rem;
+  padding: 0.65rem 0.85rem;
   border-bottom: 1px solid #e6e8eb;
   vertical-align: top;
 }
-table.studies-table th {
-  background: #f0f3f6;
-  font-weight: 600;
+table.studies-table tbody td {
+  font-size: 1rem;
   color: var(--text);
+}
+table.studies-table th {
+  background: #eef4fa;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--nanda-blue-dark);
 }
 table.studies-table th.num,
 table.studies-table td.num {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
-table.studies-table { table-layout: fixed; }
-table.studies-table col.col-id { width: 5.5rem; }
-table.studies-table col.col-num { width: 7.5rem; }
-table.studies-table col.col-num-narrow { width: 6rem; }
+table.studies-table col.col-num { width: 8.5rem; }
+table.studies-table col.col-num-narrow { width: 7rem; }
 table.studies-table .title-cell {
   white-space: normal;
   overflow-wrap: anywhere;
@@ -234,7 +246,7 @@ button.sort-btn {
   padding: 0;
   margin: 0;
   font: inherit;
-  font-weight: 600;
+  font-weight: 700;
   color: inherit;
   cursor: pointer;
   text-align: inherit;
@@ -246,10 +258,10 @@ button.sort-btn {
 table.studies-table th.num button.sort-btn {
   justify-content: flex-end;
 }
-button.sort-btn:hover { color: var(--brand-deep); }
-th[aria-sort="ascending"] button.sort-btn::after { content: "▲"; font-size: 0.7em; color: var(--brand); }
-th[aria-sort="descending"] button.sort-btn::after { content: "▼"; font-size: 0.7em; color: var(--brand); }
-th[aria-sort="none"] button.sort-btn::after { content: "↕"; font-size: 0.75em; color: var(--muted); opacity: 0.6; }
+button.sort-btn:hover { text-decoration: underline; text-underline-offset: 3px; }
+th[aria-sort="ascending"] button.sort-btn::after { content: "▲"; font-size: 0.75em; color: var(--accent); }
+th[aria-sort="descending"] button.sort-btn::after { content: "▼"; font-size: 0.75em; color: var(--accent); }
+th[aria-sort="none"] button.sort-btn::after { content: "↕"; font-size: 0.8em; color: var(--muted); opacity: 0.6; }
 
 .row-hidden { display: none; }
 
@@ -263,12 +275,12 @@ details {
   border: 1px solid var(--border);
   border-radius: 4px;
   padding: 0.5rem 0.85rem;
-  background: #fafbfc;
+  background: var(--nanda-white);
 }
 details > summary {
   cursor: pointer;
-  font-weight: 600;
-  color: var(--brand-deep);
+  font-weight: 700;
+  color: var(--nanda-blue-dark);
 }
 details[open] > summary { margin-bottom: 0.5rem; }
 details p { margin: 0.5rem 0 0; }
@@ -288,7 +300,7 @@ footer nav ul {
   flex-wrap: wrap;
   gap: 0.5rem 1.5rem;
 }
-footer nav a { font-weight: 500; }
+footer nav a { font-weight: 700; }
 footer p { margin: 0; }
 
 @media (max-width: 600px) {
@@ -412,7 +424,6 @@ footer p { margin: 0; }
   <table id="curated-table" class="studies-table" aria-describedby="curated-def">
     <caption class="visually-hidden">Curated NaNDA datasets, sortable by column.</caption>
     <colgroup>
-      <col class="col-id">
       <col>
       <col class="col-num">
       <col class="col-num">
@@ -421,7 +432,6 @@ footer p { margin: 0; }
     </colgroup>
     <thead>
       <tr>
-        <th scope="col" class="num" aria-sort="none"><button type="button" class="sort-btn" data-key="study_id" data-type="num">Study ID</button></th>
         <th scope="col" aria-sort="none"><button type="button" class="sort-btn" data-key="title" data-type="text">Title</button></th>
         <th scope="col" class="num" aria-sort="descending"><button type="button" class="sort-btn" data-key="total" data-type="num">Total downloads</button></th>
         <th scope="col" class="num" aria-sort="none"><button type="button" class="sort-btn" data-key="delta" data-type="num">Change this month</button></th>
@@ -430,25 +440,25 @@ footer p { margin: 0; }
       </tr>
     </thead>
     <tbody>
-<tr><td class="num">38506</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38506.v2">Voter Registration, Turnout, and Partisanship by County, United States, 2004-2022</a></td><td class="num" data-sort="4697">4,697</td><td class="num delta-pos" data-sort="1">+1</td><td class="num" data-sort="827">827</td><td class="num" data-sort="18">18</td></tr>
-<tr><td class="num">38528</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38528.v6">Socioeconomic Status and Demographic Characteristics of Census Tracts and ZIP Code Tabulation Areas, United States, 1990-2022</a></td><td class="num" data-sort="20280">20,280</td><td class="num delta-pos" data-sort="2">+2</td><td class="num" data-sort="863">863</td><td class="num" data-sort="134">134</td></tr>
-<tr><td class="num">38559</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38559.v1">Internet Access by Census Tract and ZIP Code Tabulation Area, United States, 2015-2019</a></td><td class="num" data-sort="939">939</td><td class="num" data-sort="0">0</td><td class="num" data-sort="135">135</td><td class="num" data-sort="4">4</td></tr>
-<tr><td class="num">38567</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38567.v1">Broadband Internet Availability, Speed, and Adoption by Census Tract and ZIP Code Tabulation Area, United States, 2014-2020</a></td><td class="num" data-sort="1505">1,505</td><td class="num" data-sort="0">0</td><td class="num" data-sort="200">200</td><td class="num" data-sort="7">7</td></tr>
-<tr><td class="num">38569</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38569.v1">School District Characteristics and School Counts by Census Tract, ZIP Code Tabulation Area, and School District, 2000-2018</a></td><td class="num" data-sort="2435">2,435</td><td class="num" data-sort="0">0</td><td class="num" data-sort="134">134</td><td class="num" data-sort="2">2</td></tr>
-<tr><td class="num">38579</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38579.v2">Neighborhood-School Gap by Census Tract and ZIP Code Tabulation Area, United States, 2009-2010 and 2015-2016</a></td><td class="num" data-sort="1773">1,773</td><td class="num" data-sort="0">0</td><td class="num" data-sort="89">89</td><td class="num" data-sort="1">1</td></tr>
-<tr><td class="num">38580</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38580.v3">Street Connectivity by Census Tract and ZIP Code Tabulation Area, United States, 2010 and 2020</a></td><td class="num" data-sort="3901">3,901</td><td class="num" data-sort="0">0</td><td class="num" data-sort="155">155</td><td class="num" data-sort="8">8</td></tr>
-<tr><td class="num">38584</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38584.v2">Traffic Volume by Census Tract and ZIP Code Tabulation Area, United States, 1963-2019</a></td><td class="num" data-sort="1844">1,844</td><td class="num delta-pos" data-sort="6">+6</td><td class="num" data-sort="228">228</td><td class="num" data-sort="11">11</td></tr>
-<tr><td class="num">38585</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38585.v2">Primary and Secondary Roads by Census Tract and ZIP Code Tabulation Area, United States, 2010 and 2020</a></td><td class="num" data-sort="1277">1,277</td><td class="num" data-sort="0">0</td><td class="num" data-sort="96">96</td><td class="num" data-sort="5">5</td></tr>
-<tr><td class="num">38586</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38586.v2">Parks by Census Tract and ZIP Code Tabulation Area, United States, 2018 and 2022</a></td><td class="num" data-sort="5179">5,179</td><td class="num" data-sort="0">0</td><td class="num" data-sort="364">364</td><td class="num" data-sort="36">36</td></tr>
-<tr><td class="num">38597</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38597.v2">Polluting Sites by Census Tract and ZIP Code Tabulation Area, United States, 1987-2021</a></td><td class="num" data-sort="3738">3,738</td><td class="num" data-sort="0">0</td><td class="num" data-sort="193">193</td><td class="num" data-sort="8">8</td></tr>
-<tr><td class="num">38598</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38598.v2">Land Cover by Census Tract and ZIP Code Tabulation Area, United States, 1985-2023</a></td><td class="num" data-sort="2905">2,905</td><td class="num" data-sort="0">0</td><td class="num" data-sort="229">229</td><td class="num" data-sort="26">26</td></tr>
-<tr><td class="num">38605</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38605.v2">Public Transit Stops by Census Tract and ZIP Code Tabulation Area, United States, 2016-2018 and 2024</a></td><td class="num" data-sort="2501">2,501</td><td class="num" data-sort="0">0</td><td class="num" data-sort="200">200</td><td class="num" data-sort="20">20</td></tr>
-<tr><td class="num">38606</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38606.v1">Urbanicity by Census Tract, United States, 2010</a></td><td class="num" data-sort="725">725</td><td class="num" data-sort="0">0</td><td class="num" data-sort="156">156</td><td class="num" data-sort="9">9</td></tr>
-<tr><td class="num">38649</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38649.v1">Crimes by County, United States, 2002-2014</a></td><td class="num" data-sort="2206">2,206</td><td class="num delta-pos" data-sort="3">+3</td><td class="num" data-sort="223">223</td><td class="num" data-sort="5">5</td></tr>
-<tr><td class="num">38858</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38858.v1">Weather by County, United States, 2003-2016</a></td><td class="num" data-sort="22964">22,964</td><td class="num" data-sort="0">0</td><td class="num" data-sort="99">99</td><td class="num" data-sort="3">3</td></tr>
-<tr><td class="num">38974</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38974.v1">Essential Workers by Census Tract and ZIP Code Tabulation Area, United States, 2016-2020</a></td><td class="num" data-sort="345">345</td><td class="num" data-sort="0">0</td><td class="num" data-sort="60">60</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">39093</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR39093.v2">Home Mortgage Disclosure Act Longitudinal Dataset by Census Tract, United States, 1981-2021</a></td><td class="num" data-sort="24897">24,897</td><td class="num" data-sort="0">0</td><td class="num" data-sort="269">269</td><td class="num" data-sort="6">6</td></tr>
-<tr><td class="num">39378</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR39378.v1">Hospitals by Census Tract and ZIP Code Tabulation Area, United States, 2023</a></td><td class="num" data-sort="769">769</td><td class="num" data-sort="0">0</td><td class="num" data-sort="67">67</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="38506"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38506.v2">Voter Registration, Turnout, and Partisanship by County, United States, 2004-2022</a></td><td class="num" data-sort="4697">4,697</td><td class="num delta-pos" data-sort="1">+1</td><td class="num" data-sort="827">827</td><td class="num" data-sort="18">18</td></tr>
+<tr data-study-id="38528"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38528.v6">Socioeconomic Status and Demographic Characteristics of Census Tracts and ZIP Code Tabulation Areas, United States, 1990-2022</a></td><td class="num" data-sort="20280">20,280</td><td class="num delta-pos" data-sort="2">+2</td><td class="num" data-sort="863">863</td><td class="num" data-sort="134">134</td></tr>
+<tr data-study-id="38559"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38559.v1">Internet Access by Census Tract and ZIP Code Tabulation Area, United States, 2015-2019</a></td><td class="num" data-sort="939">939</td><td class="num" data-sort="0">0</td><td class="num" data-sort="135">135</td><td class="num" data-sort="4">4</td></tr>
+<tr data-study-id="38567"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38567.v1">Broadband Internet Availability, Speed, and Adoption by Census Tract and ZIP Code Tabulation Area, United States, 2014-2020</a></td><td class="num" data-sort="1505">1,505</td><td class="num" data-sort="0">0</td><td class="num" data-sort="200">200</td><td class="num" data-sort="7">7</td></tr>
+<tr data-study-id="38569"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38569.v1">School District Characteristics and School Counts by Census Tract, ZIP Code Tabulation Area, and School District, 2000-2018</a></td><td class="num" data-sort="2435">2,435</td><td class="num" data-sort="0">0</td><td class="num" data-sort="134">134</td><td class="num" data-sort="2">2</td></tr>
+<tr data-study-id="38579"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38579.v2">Neighborhood-School Gap by Census Tract and ZIP Code Tabulation Area, United States, 2009-2010 and 2015-2016</a></td><td class="num" data-sort="1773">1,773</td><td class="num" data-sort="0">0</td><td class="num" data-sort="89">89</td><td class="num" data-sort="1">1</td></tr>
+<tr data-study-id="38580"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38580.v3">Street Connectivity by Census Tract and ZIP Code Tabulation Area, United States, 2010 and 2020</a></td><td class="num" data-sort="3901">3,901</td><td class="num" data-sort="0">0</td><td class="num" data-sort="155">155</td><td class="num" data-sort="8">8</td></tr>
+<tr data-study-id="38584"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38584.v2">Traffic Volume by Census Tract and ZIP Code Tabulation Area, United States, 1963-2019</a></td><td class="num" data-sort="1844">1,844</td><td class="num delta-pos" data-sort="6">+6</td><td class="num" data-sort="228">228</td><td class="num" data-sort="11">11</td></tr>
+<tr data-study-id="38585"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38585.v2">Primary and Secondary Roads by Census Tract and ZIP Code Tabulation Area, United States, 2010 and 2020</a></td><td class="num" data-sort="1277">1,277</td><td class="num" data-sort="0">0</td><td class="num" data-sort="96">96</td><td class="num" data-sort="5">5</td></tr>
+<tr data-study-id="38586"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38586.v2">Parks by Census Tract and ZIP Code Tabulation Area, United States, 2018 and 2022</a></td><td class="num" data-sort="5179">5,179</td><td class="num" data-sort="0">0</td><td class="num" data-sort="364">364</td><td class="num" data-sort="36">36</td></tr>
+<tr data-study-id="38597"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38597.v2">Polluting Sites by Census Tract and ZIP Code Tabulation Area, United States, 1987-2021</a></td><td class="num" data-sort="3738">3,738</td><td class="num" data-sort="0">0</td><td class="num" data-sort="193">193</td><td class="num" data-sort="8">8</td></tr>
+<tr data-study-id="38598"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38598.v2">Land Cover by Census Tract and ZIP Code Tabulation Area, United States, 1985-2023</a></td><td class="num" data-sort="2905">2,905</td><td class="num" data-sort="0">0</td><td class="num" data-sort="229">229</td><td class="num" data-sort="26">26</td></tr>
+<tr data-study-id="38605"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38605.v2">Public Transit Stops by Census Tract and ZIP Code Tabulation Area, United States, 2016-2018 and 2024</a></td><td class="num" data-sort="2501">2,501</td><td class="num" data-sort="0">0</td><td class="num" data-sort="200">200</td><td class="num" data-sort="20">20</td></tr>
+<tr data-study-id="38606"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38606.v1">Urbanicity by Census Tract, United States, 2010</a></td><td class="num" data-sort="725">725</td><td class="num" data-sort="0">0</td><td class="num" data-sort="156">156</td><td class="num" data-sort="9">9</td></tr>
+<tr data-study-id="38649"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38649.v1">Crimes by County, United States, 2002-2014</a></td><td class="num" data-sort="2206">2,206</td><td class="num delta-pos" data-sort="3">+3</td><td class="num" data-sort="223">223</td><td class="num" data-sort="5">5</td></tr>
+<tr data-study-id="38858"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38858.v1">Weather by County, United States, 2003-2016</a></td><td class="num" data-sort="22964">22,964</td><td class="num" data-sort="0">0</td><td class="num" data-sort="99">99</td><td class="num" data-sort="3">3</td></tr>
+<tr data-study-id="38974"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR38974.v1">Essential Workers by Census Tract and ZIP Code Tabulation Area, United States, 2016-2020</a></td><td class="num" data-sort="345">345</td><td class="num" data-sort="0">0</td><td class="num" data-sort="60">60</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="39093"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR39093.v2">Home Mortgage Disclosure Act Longitudinal Dataset by Census Tract, United States, 1981-2021</a></td><td class="num" data-sort="24897">24,897</td><td class="num" data-sort="0">0</td><td class="num" data-sort="269">269</td><td class="num" data-sort="6">6</td></tr>
+<tr data-study-id="39378"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR39378.v1">Hospitals by Census Tract and ZIP Code Tabulation Area, United States, 2023</a></td><td class="num" data-sort="769">769</td><td class="num" data-sort="0">0</td><td class="num" data-sort="67">67</td><td class="num" data-sort="0">0</td></tr>
     </tbody>
   </table>
   </div>
@@ -467,7 +477,6 @@ footer p { margin: 0; }
   <table id="self-table" class="studies-table" aria-describedby="self-def">
     <caption class="visually-hidden">Self-published NaNDA datasets, sortable by column.</caption>
     <colgroup>
-      <col class="col-id">
       <col>
       <col class="col-num">
       <col class="col-num">
@@ -475,7 +484,6 @@ footer p { margin: 0; }
     </colgroup>
     <thead>
       <tr>
-        <th scope="col" class="num" aria-sort="none"><button type="button" class="sort-btn" data-key="study_id" data-type="num">Study ID</button></th>
         <th scope="col" aria-sort="none"><button type="button" class="sort-btn" data-key="title" data-type="text">Title</button></th>
         <th scope="col" class="num" aria-sort="descending"><button type="button" class="sort-btn" data-key="total" data-type="num">Total downloads</button></th>
         <th scope="col" class="num" aria-sort="none"><button type="button" class="sort-btn" data-key="views" data-type="num">Total views</button></th>
@@ -483,91 +491,91 @@ footer p { margin: 0; }
       </tr>
     </thead>
     <tbody>
-<tr><td class="num">110663</td><td class="title-cell"><a href="https://doi.org/10.3886/E110663V10">Land Cover by Census Tract, United States, 2001-2016</a></td><td class="num" data-sort="385">385</td><td class="num" data-sort="3523">3,523</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">120088</td><td class="title-cell"><a href="https://doi.org/10.3886/E120088V21">Code for merging ZCTA level datasets with the UDS Mapper ZIP code to ZCTA crosswalk</a></td><td class="num" data-sort="207">207</td><td class="num" data-sort="3777">3,777</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">127681</td><td class="title-cell"><a href="https://doi.org/10.3886/E127681V14"> Education and Training Services by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="159">159</td><td class="num" data-sort="1053">1,053</td><td class="num delta-pos" data-sort="1">+1</td></tr>
-<tr><td class="num">127682</td><td class="title-cell"><a href="https://doi.org/10.3886/E127682V14">Education and Training Services by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="27">27</td><td class="num" data-sort="433">433</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">141121</td><td class="title-cell"><a href="https://doi.org/10.3886/E141121V36">Historic Redlining Indicator for 2000, 2010, and 2020 US Census Tracts</a></td><td class="num" data-sort="2817">2,817</td><td class="num" data-sort="26370">26,370</td><td class="num delta-pos" data-sort="2">+2</td></tr>
-<tr><td class="num">190141</td><td class="title-cell"><a href="https://doi.org/10.3886/E190141V11">Special Data Release for Neighborhood Context and Alzheimer&#x27;s Disease and Related Dementias</a></td><td class="num" data-sort="0">0</td><td class="num" data-sort="681">681</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">200038</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR200038.V5">Libraries by Census Tract and ZIP Code Tabulation Area, United States, 1992-2021</a></td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">207966</td><td class="title-cell"><a href="https://doi.org/10.3886/E207966V22">Civic, Social, and Religious Organizations by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="282">282</td><td class="num" data-sort="1123">1,123</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">208207</td><td class="title-cell"><a href="https://doi.org/10.3886/E208207V51">Social Services by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="276">276</td><td class="num" data-sort="1547">1,547</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">208366</td><td class="title-cell"><a href="https://doi.org/10.3886/E208366V22">Post Offices and Banks by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="78">78</td><td class="num" data-sort="391">391</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">208682</td><td class="title-cell"><a href="https://doi.org/10.3886/E208682V20">Retail Establishments by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="182">182</td><td class="num" data-sort="1143">1,143</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">208684</td><td class="title-cell"><a href="https://doi.org/10.3886/E208684V22">Law Enforcement by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="113">113</td><td class="num" data-sort="750">750</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">208751</td><td class="title-cell"><a href="https://doi.org/10.3886/E208751V20">Eating and Drinking Places by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="316">316</td><td class="num" data-sort="1111">1,111</td><td class="num delta-pos" data-sort="1">+1</td></tr>
-<tr><td class="num">208906</td><td class="title-cell"><a href="https://doi.org/10.3886/E208906V23">Personal Care Services and Laundry by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="95">95</td><td class="num" data-sort="344">344</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">208907</td><td class="title-cell"><a href="https://doi.org/10.3886/E208907V20">Liquor, Tobacco, Cannabis, Vape, and Convenience Stores by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="229">229</td><td class="num" data-sort="1824">1,824</td><td class="num delta-pos" data-sort="1">+1</td></tr>
-<tr><td class="num">209050</td><td class="title-cell"><a href="https://doi.org/10.3886/E209050V21">Healthcare Services by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="391">391</td><td class="num" data-sort="1891">1,891</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">209163</td><td class="title-cell"><a href="https://doi.org/10.3886/E209163V30">Arts, Entertainment, and Leisure Establishments by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="204">204</td><td class="num" data-sort="996">996</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">209164</td><td class="title-cell"><a href="https://doi.org/10.3886/E209164V30">Recreational Establishments by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="200">200</td><td class="num" data-sort="805">805</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">209313</td><td class="title-cell"><a href="https://doi.org/10.3886/E209313V20">Grocery and Food Stores by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="386">386</td><td class="num" data-sort="1968">1,968</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">209324</td><td class="title-cell"><a href="https://doi.org/10.3886/E209324V21">Dollar Stores by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="50">50</td><td class="num" data-sort="266">266</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">210581</td><td class="title-cell"><a href="https://doi.org/10.3886/E210581V19">Standardized Area Deprivation Index (ADI) by Census Block Group, United States, 2015, 2020 and 2022</a></td><td class="num" data-sort="127">127</td><td class="num" data-sort="7285">7,285</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">220701</td><td class="title-cell"><a href="https://doi.org/10.3886/E220701V14">Land Cover by Census Tract and ZIP Code Tabulation Area, United States, 1985- 2023</a></td><td class="num" data-sort="43">43</td><td class="num" data-sort="370">370</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">222263</td><td class="title-cell"><a href="https://doi.org/10.3886/E222263V12">Ophthalmologists by Census Tract and ZCTA, United States, 1990-2021</a></td><td class="num" data-sort="14">14</td><td class="num" data-sort="199">199</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">222901</td><td class="title-cell"><a href="https://doi.org/10.3886/E222901V13">Hospitals by Census Tract and ZCTA, 2023</a></td><td class="num" data-sort="41">41</td><td class="num" data-sort="327">327</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">230941</td><td class="title-cell"><a href="https://doi.org/10.3886/E230941V25">PRISM Climate of Census Tracts, United States, 1981-2024</a></td><td class="num" data-sort="138">138</td><td class="num" data-sort="1212">1,212</td><td class="num delta-pos" data-sort="1">+1</td></tr>
-<tr><td class="num">237305</td><td class="title-cell"><a href="https://doi.org/10.3886/E237305V11">National Neighborhood Data Archive: Air Conditioning Probability by Census Tract, United States, 2016</a></td><td class="num" data-sort="30">30</td><td class="num" data-sort="264">264</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">301419</td><td class="title-cell"><a href="https://doi.org/10.3886/E301419V11">Essential Businesses in Census Tracts or ZIP Code Tabulation Areas, United States, 2020</a></td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">302178</td><td class="title-cell"><a href="https://doi.org/10.3886/E302178V10">Essential Workers by Census Tract and ZIP Code Tabulation Area, United States, 2018-2022</a></td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">302343</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR302343.v1">Training and Vocation Schools by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">302937</td><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR302937.v1">Broadband Availability by Census Tract and ZIP Code Tabulation Area (ZCTA), United States, 2025. </a></td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">110641</td><td class="title-cell"><a href="https://doi.org/10.3886/E110641V1">Street Connectivity by Census Tract, United States, 2010</a></td><td class="num" data-sort="95">95</td><td class="num" data-sort="988">988</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">111107</td><td class="title-cell"><a href="https://doi.org/10.3886/E111107V1">Neighborhood Socioeconomic and Demographic Characteristics of Census Tracts, United States, 2000-2010</a></td><td class="num" data-sort="324">324</td><td class="num" data-sort="3930">3,930</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">111109</td><td class="title-cell"><a href="https://doi.org/10.3886/E111109V1">Public Transit Stops by Census Tract, United States, 2016-2018</a></td><td class="num" data-sort="221">221</td><td class="num" data-sort="2408">2,408</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">115006</td><td class="title-cell"><a href="https://doi.org/10.3886/E115006V1">Crimes by County, United States, 2002-2014</a></td><td class="num" data-sort="289">289</td><td class="num" data-sort="3047">3,047</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">115323</td><td class="title-cell"><a href="https://doi.org/10.3886/E115323V1">Fast-Food Restaurants by Census Tract, United States, 2006-2015</a></td><td class="num" data-sort="9">9</td><td class="num" data-sort="2357">2,357</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">115404</td><td class="title-cell"><a href="https://doi.org/10.3886/E115404V1">Eating and Drinking Places by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="340">340</td><td class="num" data-sort="2535">2,535</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">115407</td><td class="title-cell"><a href="https://doi.org/10.3886/E115407V1">Religious Organizations by Census Tract, United States, 2006-2015</a></td><td class="num" data-sort="4">4</td><td class="num" data-sort="363">363</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">115408</td><td class="title-cell"><a href="https://doi.org/10.3886/E115408V1">Civic and Social Organizations by Census Tract, United States, 2006-2015</a></td><td class="num" data-sort="9">9</td><td class="num" data-sort="543">543</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">115543</td><td class="title-cell"><a href="https://doi.org/10.3886/E115543V1"> Arts, Entertainment, and Recreation Organizations by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="299">299</td><td class="num" data-sort="2325">2,325</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">115967</td><td class="title-cell"><a href="https://doi.org/10.3886/E115967V1"> Religious, Civic, and Social Organizations by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="267">267</td><td class="num" data-sort="2161">2,161</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">115972</td><td class="title-cell"><a href="https://doi.org/10.3886/E115972V1"> Retail Establishments by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="205">205</td><td class="num" data-sort="1893">1,893</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">115973</td><td class="title-cell"><a href="https://doi.org/10.3886/E115973V1"> Law Enforcement Organizations by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="143">143</td><td class="num" data-sort="1475">1,475</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">115981</td><td class="title-cell"><a href="https://doi.org/10.3886/E115981V1"> Personal Care Services and Laundromats by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="137">137</td><td class="num" data-sort="1090">1,090</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">117163</td><td class="title-cell"><a href="https://doi.org/10.3886/E117163V1">Social Services by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="315">315</td><td class="num" data-sort="2275">2,275</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">117866</td><td class="title-cell"><a href="https://doi.org/10.3886/E117866V1">Broadband Internet Availability, Speed, and Adoption by Census Tract, United States, 2014-2020</a></td><td class="num" data-sort="228">228</td><td class="num" data-sort="2401">2,401</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">117921</td><td class="title-cell"><a href="https://doi.org/10.3886/E117921V1">Parks by Census Tract, United States, 2018</a></td><td class="num" data-sort="403">403</td><td class="num" data-sort="3684">3,684</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">119451</td><td class="title-cell"><a href="https://doi.org/10.3886/E119451V1"> Socioeconomic Status and Demographic Characteristics of Census Tracts, United States, 2008-2017</a></td><td class="num" data-sort="529">529</td><td class="num" data-sort="4566">4,566</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">119803</td><td class="title-cell"><a href="https://doi.org/10.3886/E119803V1">Parks by ZIP Code Tabulation Area, United States, 2018</a></td><td class="num" data-sort="163">163</td><td class="num" data-sort="2075">2,075</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">120462</td><td class="title-cell"><a href="https://doi.org/10.3886/E120462V1">Socioeconomic Status and Demographic Characteristics of ZIP Code Tabulation Areas, United States, 2008-2017</a></td><td class="num" data-sort="533">533</td><td class="num" data-sort="17219">17,219</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">120463</td><td class="title-cell"><a href="https://doi.org/10.3886/E120463V1">Health Care Services by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="201">201</td><td class="num" data-sort="1922">1,922</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">120907</td><td class="title-cell"><a href="https://doi.org/10.3886/E120907V1">Health Care Services by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="484">484</td><td class="num" data-sort="3987">3,987</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">121741</td><td class="title-cell"><a href="https://doi.org/10.3886/E121741V1">Eating and Drinking Places by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="88">88</td><td class="num" data-sort="989">989</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">123001</td><td class="title-cell"><a href="https://doi.org/10.3886/E123001V1">Grocery Stores by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="371">371</td><td class="num" data-sort="2511">2,511</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">123042</td><td class="title-cell"><a href="https://doi.org/10.3886/E123042V1">Grocery Stores by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="134">134</td><td class="num" data-sort="2020">2,020</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">123541</td><td class="title-cell"><a href="https://doi.org/10.3886/E123541V1">Liquor, Tobacco, and Convenience Stores by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="188">188</td><td class="num" data-sort="1373">1,373</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">123542</td><td class="title-cell"><a href="https://doi.org/10.3886/E123542V1">Liquor, Tobacco, and Convenience Stores by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="51">51</td><td class="num" data-sort="554">554</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">123801</td><td class="title-cell"><a href="https://doi.org/10.3886/E123801V1">Dollar Stores by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="48">48</td><td class="num" data-sort="650">650</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">123802</td><td class="title-cell"><a href="https://doi.org/10.3886/E123802V1">Dollar Stores by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="126">126</td><td class="num" data-sort="943">943</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">124721</td><td class="title-cell"><a href="https://doi.org/10.3886/E124721V1">Religious, Civic, and Social Organizations by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="115">115</td><td class="num" data-sort="1664">1,664</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">124801</td><td class="title-cell"><a href="https://doi.org/10.3886/E124801V1">Law Enforcement Organizations by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="41">41</td><td class="num" data-sort="448">448</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">125223</td><td class="title-cell"><a href="https://doi.org/10.3886/E125223V1">Arts, Entertainment, and Recreation Organizations by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="104">104</td><td class="num" data-sort="779">779</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">125781</td><td class="title-cell"><a href="https://doi.org/10.3886/E125781V1">Voter Registration, Turnout, and Partisanship by County, United States, 2004-2018</a></td><td class="num" data-sort="303">303</td><td class="num" data-sort="4378">4,378</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">126082</td><td class="title-cell"><a href="https://doi.org/10.3886/E126082V1">Social Services by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="85">85</td><td class="num" data-sort="735">735</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">127042</td><td class="title-cell"><a href="https://doi.org/10.3886/E127042V1">Retail Establishments by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="68">68</td><td class="num" data-sort="972">972</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">127262</td><td class="title-cell"><a href="https://doi.org/10.3886/E127262V1">Personal Care Services and Laundromats by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="34">34</td><td class="num" data-sort="409">409</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">128281</td><td class="title-cell"><a href="https://doi.org/10.3886/E128281V1"> Post Offices and Banks by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="115">115</td><td class="num" data-sort="877">877</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">128282</td><td class="title-cell"><a href="https://doi.org/10.3886/E128282V1">Post Offices and Banks by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="32">32</td><td class="num" data-sort="388">388</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">128841</td><td class="title-cell"><a href="https://doi.org/10.3886/E128841V1">Broadband Internet Availability and Speed by ZIP Code Tabulation Area, United States, 2014-2020</a></td><td class="num" data-sort="273">273</td><td class="num" data-sort="3684">3,684</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">128862</td><td class="title-cell"><a href="https://doi.org/10.3886/E128862V1">Land Cover by ZIP Code Tabulation Area, United States, 2001-2016</a></td><td class="num" data-sort="109">109</td><td class="num" data-sort="1758">1,758</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">130282</td><td class="title-cell"><a href="https://doi.org/10.3886/E130282V1">Public Transit Stops by ZIP Code Tabulation Area, United States, 2016-2018</a></td><td class="num" data-sort="110">110</td><td class="num" data-sort="1710">1,710</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">130542</td><td class="title-cell"><a href="https://doi.org/10.3886/E130542V1">Urbanicity by Census Tract, United States, 2010</a></td><td class="num" data-sort="102">102</td><td class="num" data-sort="1445">1,445</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">134561</td><td class="title-cell"><a href="https://doi.org/10.3886/E134561V1">Street Connectivity by ZIP Code Tabulation Area, United States, 2010</a></td><td class="num" data-sort="31">31</td><td class="num" data-sort="962">962</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">155022</td><td class="title-cell"><a href="https://doi.org/10.3886/E155022V1">Internet Access by Census Tract, United States, 2015-2019</a></td><td class="num" data-sort="62">62</td><td class="num" data-sort="426">426</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">155025</td><td class="title-cell"><a href="https://doi.org/10.3886/E155025V1">Internet Access by ZIP Code Tabulation Area, United States, 2015-2019</a></td><td class="num" data-sort="44">44</td><td class="num" data-sort="413">413</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">156024</td><td class="title-cell"><a href="https://doi.org/10.3886/E156024V1">School Counts by Census Tract, United States, 2000-2018</a></td><td class="num" data-sort="74">74</td><td class="num" data-sort="458">458</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">156041</td><td class="title-cell"><a href="https://doi.org/10.3886/E156041V1">School Counts by ZIP Code Tabulation Area, United States, 2000-2018</a></td><td class="num" data-sort="36">36</td><td class="num" data-sort="302">302</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">156042</td><td class="title-cell"><a href="https://doi.org/10.3886/E156042V1">School Counts and Characteristics by School District, United States, 2000-2018</a></td><td class="num" data-sort="61">61</td><td class="num" data-sort="569">569</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">156043</td><td class="title-cell"><a href="https://doi.org/10.3886/E156043V1">Neighborhood-School Gap by Census Tract, United States, 2009-2010 and 2015-2016</a></td><td class="num" data-sort="63">63</td><td class="num" data-sort="458">458</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">156045</td><td class="title-cell"><a href="https://doi.org/10.3886/E156045V1">Neighborhood-School Gap by ZIP Code Tabulation Area, United States, 2009-2010 and 2015-2016</a></td><td class="num" data-sort="24">24</td><td class="num" data-sort="511">511</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">159902</td><td class="title-cell"><a href="https://doi.org/10.3886/E159902V1">Primary and Secondary Roads by Census Tract, United States, 2010</a></td><td class="num" data-sort="56">56</td><td class="num" data-sort="788">788</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">159941</td><td class="title-cell"><a href="https://doi.org/10.3886/E159941V1">Primary and Secondary Roads by ZIP Code Tabulation Area, United States, 2010</a></td><td class="num" data-sort="18">18</td><td class="num" data-sort="874">874</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">159961</td><td class="title-cell"><a href="https://doi.org/10.3886/E159961V1">Polluting Sites by Census Tract, United States, 2000-2018</a></td><td class="num" data-sort="125">125</td><td class="num" data-sort="1015">1,015</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">159981</td><td class="title-cell"><a href="https://doi.org/10.3886/E159981V1">Polluting Sites by ZIP Code Tabulation Area, United States, 2000-2018</a></td><td class="num" data-sort="58">58</td><td class="num" data-sort="518">518</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">160261</td><td class="title-cell"><a href="https://doi.org/10.3886/E160261V1">Traffic Volume by ZIP Code Tabulation Area, United States, 1963-2019</a></td><td class="num" data-sort="186">186</td><td class="num" data-sort="2798">2,798</td><td class="num" data-sort="0">0</td></tr>
-<tr><td class="num">160262</td><td class="title-cell"><a href="https://doi.org/10.3886/E160262V1">Traffic Volume by Census Tract, United States, 1963-2019</a></td><td class="num" data-sort="197">197</td><td class="num" data-sort="1978">1,978</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="110663"><td class="title-cell"><a href="https://doi.org/10.3886/E110663V10">Land Cover by Census Tract, United States, 2001-2016</a></td><td class="num" data-sort="385">385</td><td class="num" data-sort="3523">3,523</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="120088"><td class="title-cell"><a href="https://doi.org/10.3886/E120088V21">Code for merging ZCTA level datasets with the UDS Mapper ZIP code to ZCTA crosswalk</a></td><td class="num" data-sort="207">207</td><td class="num" data-sort="3777">3,777</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="127681"><td class="title-cell"><a href="https://doi.org/10.3886/E127681V14"> Education and Training Services by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="159">159</td><td class="num" data-sort="1053">1,053</td><td class="num delta-pos" data-sort="1">+1</td></tr>
+<tr data-study-id="127682"><td class="title-cell"><a href="https://doi.org/10.3886/E127682V14">Education and Training Services by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="27">27</td><td class="num" data-sort="433">433</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="141121"><td class="title-cell"><a href="https://doi.org/10.3886/E141121V36">Historic Redlining Indicator for 2000, 2010, and 2020 US Census Tracts</a></td><td class="num" data-sort="2817">2,817</td><td class="num" data-sort="26370">26,370</td><td class="num delta-pos" data-sort="2">+2</td></tr>
+<tr data-study-id="190141"><td class="title-cell"><a href="https://doi.org/10.3886/E190141V11">Special Data Release for Neighborhood Context and Alzheimer&#x27;s Disease and Related Dementias</a></td><td class="num" data-sort="0">0</td><td class="num" data-sort="681">681</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="200038"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR200038.V5">Libraries by Census Tract and ZIP Code Tabulation Area, United States, 1992-2021</a></td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="207966"><td class="title-cell"><a href="https://doi.org/10.3886/E207966V22">Civic, Social, and Religious Organizations by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="282">282</td><td class="num" data-sort="1123">1,123</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="208207"><td class="title-cell"><a href="https://doi.org/10.3886/E208207V51">Social Services by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="276">276</td><td class="num" data-sort="1547">1,547</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="208366"><td class="title-cell"><a href="https://doi.org/10.3886/E208366V22">Post Offices and Banks by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="78">78</td><td class="num" data-sort="391">391</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="208682"><td class="title-cell"><a href="https://doi.org/10.3886/E208682V20">Retail Establishments by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="182">182</td><td class="num" data-sort="1143">1,143</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="208684"><td class="title-cell"><a href="https://doi.org/10.3886/E208684V22">Law Enforcement by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="113">113</td><td class="num" data-sort="750">750</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="208751"><td class="title-cell"><a href="https://doi.org/10.3886/E208751V20">Eating and Drinking Places by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="316">316</td><td class="num" data-sort="1111">1,111</td><td class="num delta-pos" data-sort="1">+1</td></tr>
+<tr data-study-id="208906"><td class="title-cell"><a href="https://doi.org/10.3886/E208906V23">Personal Care Services and Laundry by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="95">95</td><td class="num" data-sort="344">344</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="208907"><td class="title-cell"><a href="https://doi.org/10.3886/E208907V20">Liquor, Tobacco, Cannabis, Vape, and Convenience Stores by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="229">229</td><td class="num" data-sort="1824">1,824</td><td class="num delta-pos" data-sort="1">+1</td></tr>
+<tr data-study-id="209050"><td class="title-cell"><a href="https://doi.org/10.3886/E209050V21">Healthcare Services by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="391">391</td><td class="num" data-sort="1891">1,891</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="209163"><td class="title-cell"><a href="https://doi.org/10.3886/E209163V30">Arts, Entertainment, and Leisure Establishments by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="204">204</td><td class="num" data-sort="996">996</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="209164"><td class="title-cell"><a href="https://doi.org/10.3886/E209164V30">Recreational Establishments by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="200">200</td><td class="num" data-sort="805">805</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="209313"><td class="title-cell"><a href="https://doi.org/10.3886/E209313V20">Grocery and Food Stores by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="386">386</td><td class="num" data-sort="1968">1,968</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="209324"><td class="title-cell"><a href="https://doi.org/10.3886/E209324V21">Dollar Stores by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="50">50</td><td class="num" data-sort="266">266</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="210581"><td class="title-cell"><a href="https://doi.org/10.3886/E210581V19">Standardized Area Deprivation Index (ADI) by Census Block Group, United States, 2015, 2020 and 2022</a></td><td class="num" data-sort="127">127</td><td class="num" data-sort="7285">7,285</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="220701"><td class="title-cell"><a href="https://doi.org/10.3886/E220701V14">Land Cover by Census Tract and ZIP Code Tabulation Area, United States, 1985- 2023</a></td><td class="num" data-sort="43">43</td><td class="num" data-sort="370">370</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="222263"><td class="title-cell"><a href="https://doi.org/10.3886/E222263V12">Ophthalmologists by Census Tract and ZCTA, United States, 1990-2021</a></td><td class="num" data-sort="14">14</td><td class="num" data-sort="199">199</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="222901"><td class="title-cell"><a href="https://doi.org/10.3886/E222901V13">Hospitals by Census Tract and ZCTA, 2023</a></td><td class="num" data-sort="41">41</td><td class="num" data-sort="327">327</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="230941"><td class="title-cell"><a href="https://doi.org/10.3886/E230941V25">PRISM Climate of Census Tracts, United States, 1981-2024</a></td><td class="num" data-sort="138">138</td><td class="num" data-sort="1212">1,212</td><td class="num delta-pos" data-sort="1">+1</td></tr>
+<tr data-study-id="237305"><td class="title-cell"><a href="https://doi.org/10.3886/E237305V11">National Neighborhood Data Archive: Air Conditioning Probability by Census Tract, United States, 2016</a></td><td class="num" data-sort="30">30</td><td class="num" data-sort="264">264</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="301419"><td class="title-cell"><a href="https://doi.org/10.3886/E301419V11">Essential Businesses in Census Tracts or ZIP Code Tabulation Areas, United States, 2020</a></td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="302178"><td class="title-cell"><a href="https://doi.org/10.3886/E302178V10">Essential Workers by Census Tract and ZIP Code Tabulation Area, United States, 2018-2022</a></td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="302343"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR302343.v1">Training and Vocation Schools by Census Tract and ZCTA, United States, 1990-2022</a></td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="302937"><td class="title-cell"><a href="https://doi.org/10.3886/ICPSR302937.v1">Broadband Availability by Census Tract and ZIP Code Tabulation Area (ZCTA), United States, 2025. </a></td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="110641"><td class="title-cell"><a href="https://doi.org/10.3886/E110641V1">Street Connectivity by Census Tract, United States, 2010</a></td><td class="num" data-sort="95">95</td><td class="num" data-sort="988">988</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="111107"><td class="title-cell"><a href="https://doi.org/10.3886/E111107V1">Neighborhood Socioeconomic and Demographic Characteristics of Census Tracts, United States, 2000-2010</a></td><td class="num" data-sort="324">324</td><td class="num" data-sort="3930">3,930</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="111109"><td class="title-cell"><a href="https://doi.org/10.3886/E111109V1">Public Transit Stops by Census Tract, United States, 2016-2018</a></td><td class="num" data-sort="221">221</td><td class="num" data-sort="2408">2,408</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="115006"><td class="title-cell"><a href="https://doi.org/10.3886/E115006V1">Crimes by County, United States, 2002-2014</a></td><td class="num" data-sort="289">289</td><td class="num" data-sort="3047">3,047</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="115323"><td class="title-cell"><a href="https://doi.org/10.3886/E115323V1">Fast-Food Restaurants by Census Tract, United States, 2006-2015</a></td><td class="num" data-sort="9">9</td><td class="num" data-sort="2357">2,357</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="115404"><td class="title-cell"><a href="https://doi.org/10.3886/E115404V1">Eating and Drinking Places by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="340">340</td><td class="num" data-sort="2535">2,535</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="115407"><td class="title-cell"><a href="https://doi.org/10.3886/E115407V1">Religious Organizations by Census Tract, United States, 2006-2015</a></td><td class="num" data-sort="4">4</td><td class="num" data-sort="363">363</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="115408"><td class="title-cell"><a href="https://doi.org/10.3886/E115408V1">Civic and Social Organizations by Census Tract, United States, 2006-2015</a></td><td class="num" data-sort="9">9</td><td class="num" data-sort="543">543</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="115543"><td class="title-cell"><a href="https://doi.org/10.3886/E115543V1"> Arts, Entertainment, and Recreation Organizations by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="299">299</td><td class="num" data-sort="2325">2,325</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="115967"><td class="title-cell"><a href="https://doi.org/10.3886/E115967V1"> Religious, Civic, and Social Organizations by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="267">267</td><td class="num" data-sort="2161">2,161</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="115972"><td class="title-cell"><a href="https://doi.org/10.3886/E115972V1"> Retail Establishments by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="205">205</td><td class="num" data-sort="1893">1,893</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="115973"><td class="title-cell"><a href="https://doi.org/10.3886/E115973V1"> Law Enforcement Organizations by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="143">143</td><td class="num" data-sort="1475">1,475</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="115981"><td class="title-cell"><a href="https://doi.org/10.3886/E115981V1"> Personal Care Services and Laundromats by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="137">137</td><td class="num" data-sort="1090">1,090</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="117163"><td class="title-cell"><a href="https://doi.org/10.3886/E117163V1">Social Services by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="315">315</td><td class="num" data-sort="2275">2,275</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="117866"><td class="title-cell"><a href="https://doi.org/10.3886/E117866V1">Broadband Internet Availability, Speed, and Adoption by Census Tract, United States, 2014-2020</a></td><td class="num" data-sort="228">228</td><td class="num" data-sort="2401">2,401</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="117921"><td class="title-cell"><a href="https://doi.org/10.3886/E117921V1">Parks by Census Tract, United States, 2018</a></td><td class="num" data-sort="403">403</td><td class="num" data-sort="3684">3,684</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="119451"><td class="title-cell"><a href="https://doi.org/10.3886/E119451V1"> Socioeconomic Status and Demographic Characteristics of Census Tracts, United States, 2008-2017</a></td><td class="num" data-sort="529">529</td><td class="num" data-sort="4566">4,566</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="119803"><td class="title-cell"><a href="https://doi.org/10.3886/E119803V1">Parks by ZIP Code Tabulation Area, United States, 2018</a></td><td class="num" data-sort="163">163</td><td class="num" data-sort="2075">2,075</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="120462"><td class="title-cell"><a href="https://doi.org/10.3886/E120462V1">Socioeconomic Status and Demographic Characteristics of ZIP Code Tabulation Areas, United States, 2008-2017</a></td><td class="num" data-sort="533">533</td><td class="num" data-sort="17219">17,219</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="120463"><td class="title-cell"><a href="https://doi.org/10.3886/E120463V1">Health Care Services by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="201">201</td><td class="num" data-sort="1922">1,922</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="120907"><td class="title-cell"><a href="https://doi.org/10.3886/E120907V1">Health Care Services by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="484">484</td><td class="num" data-sort="3987">3,987</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="121741"><td class="title-cell"><a href="https://doi.org/10.3886/E121741V1">Eating and Drinking Places by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="88">88</td><td class="num" data-sort="989">989</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="123001"><td class="title-cell"><a href="https://doi.org/10.3886/E123001V1">Grocery Stores by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="371">371</td><td class="num" data-sort="2511">2,511</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="123042"><td class="title-cell"><a href="https://doi.org/10.3886/E123042V1">Grocery Stores by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="134">134</td><td class="num" data-sort="2020">2,020</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="123541"><td class="title-cell"><a href="https://doi.org/10.3886/E123541V1">Liquor, Tobacco, and Convenience Stores by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="188">188</td><td class="num" data-sort="1373">1,373</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="123542"><td class="title-cell"><a href="https://doi.org/10.3886/E123542V1">Liquor, Tobacco, and Convenience Stores by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="51">51</td><td class="num" data-sort="554">554</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="123801"><td class="title-cell"><a href="https://doi.org/10.3886/E123801V1">Dollar Stores by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="48">48</td><td class="num" data-sort="650">650</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="123802"><td class="title-cell"><a href="https://doi.org/10.3886/E123802V1">Dollar Stores by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="126">126</td><td class="num" data-sort="943">943</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="124721"><td class="title-cell"><a href="https://doi.org/10.3886/E124721V1">Religious, Civic, and Social Organizations by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="115">115</td><td class="num" data-sort="1664">1,664</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="124801"><td class="title-cell"><a href="https://doi.org/10.3886/E124801V1">Law Enforcement Organizations by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="41">41</td><td class="num" data-sort="448">448</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="125223"><td class="title-cell"><a href="https://doi.org/10.3886/E125223V1">Arts, Entertainment, and Recreation Organizations by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="104">104</td><td class="num" data-sort="779">779</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="125781"><td class="title-cell"><a href="https://doi.org/10.3886/E125781V1">Voter Registration, Turnout, and Partisanship by County, United States, 2004-2018</a></td><td class="num" data-sort="303">303</td><td class="num" data-sort="4378">4,378</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="126082"><td class="title-cell"><a href="https://doi.org/10.3886/E126082V1">Social Services by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="85">85</td><td class="num" data-sort="735">735</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="127042"><td class="title-cell"><a href="https://doi.org/10.3886/E127042V1">Retail Establishments by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="68">68</td><td class="num" data-sort="972">972</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="127262"><td class="title-cell"><a href="https://doi.org/10.3886/E127262V1">Personal Care Services and Laundromats by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="34">34</td><td class="num" data-sort="409">409</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="128281"><td class="title-cell"><a href="https://doi.org/10.3886/E128281V1"> Post Offices and Banks by Census Tract, United States, 2003-2017</a></td><td class="num" data-sort="115">115</td><td class="num" data-sort="877">877</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="128282"><td class="title-cell"><a href="https://doi.org/10.3886/E128282V1">Post Offices and Banks by ZIP Code Tabulation Area, United States, 2003-2017</a></td><td class="num" data-sort="32">32</td><td class="num" data-sort="388">388</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="128841"><td class="title-cell"><a href="https://doi.org/10.3886/E128841V1">Broadband Internet Availability and Speed by ZIP Code Tabulation Area, United States, 2014-2020</a></td><td class="num" data-sort="273">273</td><td class="num" data-sort="3684">3,684</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="128862"><td class="title-cell"><a href="https://doi.org/10.3886/E128862V1">Land Cover by ZIP Code Tabulation Area, United States, 2001-2016</a></td><td class="num" data-sort="109">109</td><td class="num" data-sort="1758">1,758</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="130282"><td class="title-cell"><a href="https://doi.org/10.3886/E130282V1">Public Transit Stops by ZIP Code Tabulation Area, United States, 2016-2018</a></td><td class="num" data-sort="110">110</td><td class="num" data-sort="1710">1,710</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="130542"><td class="title-cell"><a href="https://doi.org/10.3886/E130542V1">Urbanicity by Census Tract, United States, 2010</a></td><td class="num" data-sort="102">102</td><td class="num" data-sort="1445">1,445</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="134561"><td class="title-cell"><a href="https://doi.org/10.3886/E134561V1">Street Connectivity by ZIP Code Tabulation Area, United States, 2010</a></td><td class="num" data-sort="31">31</td><td class="num" data-sort="962">962</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="155022"><td class="title-cell"><a href="https://doi.org/10.3886/E155022V1">Internet Access by Census Tract, United States, 2015-2019</a></td><td class="num" data-sort="62">62</td><td class="num" data-sort="426">426</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="155025"><td class="title-cell"><a href="https://doi.org/10.3886/E155025V1">Internet Access by ZIP Code Tabulation Area, United States, 2015-2019</a></td><td class="num" data-sort="44">44</td><td class="num" data-sort="413">413</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="156024"><td class="title-cell"><a href="https://doi.org/10.3886/E156024V1">School Counts by Census Tract, United States, 2000-2018</a></td><td class="num" data-sort="74">74</td><td class="num" data-sort="458">458</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="156041"><td class="title-cell"><a href="https://doi.org/10.3886/E156041V1">School Counts by ZIP Code Tabulation Area, United States, 2000-2018</a></td><td class="num" data-sort="36">36</td><td class="num" data-sort="302">302</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="156042"><td class="title-cell"><a href="https://doi.org/10.3886/E156042V1">School Counts and Characteristics by School District, United States, 2000-2018</a></td><td class="num" data-sort="61">61</td><td class="num" data-sort="569">569</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="156043"><td class="title-cell"><a href="https://doi.org/10.3886/E156043V1">Neighborhood-School Gap by Census Tract, United States, 2009-2010 and 2015-2016</a></td><td class="num" data-sort="63">63</td><td class="num" data-sort="458">458</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="156045"><td class="title-cell"><a href="https://doi.org/10.3886/E156045V1">Neighborhood-School Gap by ZIP Code Tabulation Area, United States, 2009-2010 and 2015-2016</a></td><td class="num" data-sort="24">24</td><td class="num" data-sort="511">511</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="159902"><td class="title-cell"><a href="https://doi.org/10.3886/E159902V1">Primary and Secondary Roads by Census Tract, United States, 2010</a></td><td class="num" data-sort="56">56</td><td class="num" data-sort="788">788</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="159941"><td class="title-cell"><a href="https://doi.org/10.3886/E159941V1">Primary and Secondary Roads by ZIP Code Tabulation Area, United States, 2010</a></td><td class="num" data-sort="18">18</td><td class="num" data-sort="874">874</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="159961"><td class="title-cell"><a href="https://doi.org/10.3886/E159961V1">Polluting Sites by Census Tract, United States, 2000-2018</a></td><td class="num" data-sort="125">125</td><td class="num" data-sort="1015">1,015</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="159981"><td class="title-cell"><a href="https://doi.org/10.3886/E159981V1">Polluting Sites by ZIP Code Tabulation Area, United States, 2000-2018</a></td><td class="num" data-sort="58">58</td><td class="num" data-sort="518">518</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="160261"><td class="title-cell"><a href="https://doi.org/10.3886/E160261V1">Traffic Volume by ZIP Code Tabulation Area, United States, 1963-2019</a></td><td class="num" data-sort="186">186</td><td class="num" data-sort="2798">2,798</td><td class="num" data-sort="0">0</td></tr>
+<tr data-study-id="160262"><td class="title-cell"><a href="https://doi.org/10.3886/E160262V1">Traffic Volume by Census Tract, United States, 1963-2019</a></td><td class="num" data-sort="197">197</td><td class="num" data-sort="1978">1,978</td><td class="num" data-sort="0">0</td></tr>
     </tbody>
   </table>
   </div>
@@ -609,11 +617,13 @@ new Chart(document.getElementById("ts-chart"), {
     datasets: [{
       label: "Downloads",
       data: tsValues,
-      borderColor: "#01528a",
-      backgroundColor: "rgba(1, 82, 138, 0.12)",
+      borderColor: "#1499d6",
+      backgroundColor: "rgba(20, 153, 214, 0.15)",
+      borderWidth: 2,
       fill: true,
       tension: 0.25,
       pointRadius: 2,
+      pointBackgroundColor: "#01528a",
     }],
   },
   options: {
@@ -630,11 +640,13 @@ new Chart(document.getElementById("ts-chart"), {
     scales: {
       y: {
         beginAtZero: true,
-        ticks: { callback: v => v.toLocaleString() },
-        title: { display: true, text: "Downloads per month", color: "#555555", font: { size: 12 } },
+        ticks: { callback: v => v.toLocaleString(), color: "#01528a" },
+        title: { display: true, text: "Downloads per month", color: "#01528a", font: { size: 13, weight: "700" } },
+        grid: { color: "rgba(1, 82, 138, 0.08)" },
       },
       x: {
-        ticks: { maxRotation: 45, autoSkip: true, maxTicksLimit: 16 },
+        ticks: { maxRotation: 45, autoSkip: true, maxTicksLimit: 16, color: "#01528a" },
+        grid: { color: "rgba(1, 82, 138, 0.08)" },
       },
     },
   },
@@ -699,8 +711,8 @@ new Chart(document.getElementById("ts-chart"), {
       const q = input.value.trim().toLowerCase();
       let visible = 0;
       Array.from(table.tBodies[0].rows).forEach(function(row) {
-        const id = row.cells[0].textContent.toLowerCase();
-        const title = row.cells[1].textContent.toLowerCase();
+        const id = (row.dataset.studyId || "").toLowerCase();
+        const title = row.cells[0].textContent.toLowerCase();
         const match = q === "" || id.includes(q) || title.includes(q);
         row.classList.toggle("row-hidden", !match);
         if (match) visible++;


### PR DESCRIPTION
Visual revisions for the dashboard following the first accessibility pass.

NaNDA brand colors via CSS custom properties on :root
- --nanda-blue-dark (#01528a): primary text, headings, links, KPI numbers
- --nanda-blue-light (#1499d6): chart line, active sort indicator
- --nanda-white (#ffffff): page background (replaces light gray)
- Cards/sections gain a 1px border now that bg and surface are both white

Atkinson Hyperlegible typeface
- Loaded from Google Fonts (weights 400 and 700) with preconnect
- Applied to body with system-ui/Segoe UI/Roboto fallback chain
- All font-weight values normalized to 400 or 700 (was 500/600 mixed)

All Studies tables
- Drop the Study ID column from rendering; preserve as data-study-id on each <tr> so the ID is still present in the markup. Filter input still matches by study ID via the data attribute.
- Bump body cell font-size to 1rem; column headers to 0.875rem
- Min-width raised to 720px to absorb the larger cells; horizontal scroll inside .table-scroll handles narrow viewports

Verification
- axe-core: 0 violations, 53 passes (up from 52)
- Manual contrast on white bg: NaNDA-blue-dark text 8.15:1, muted text 7.46:1, definition box 7.31:1, table header 7.36:1, KPI delta positive (semantic green) 5.08:1 — all pass WCAG AA
- Filter by study ID still works via dataset.studyId
- Sort still works on total downloads column (now index 1, was 2)
- Both font weights confirmed loaded via document.fonts.check()