### PR TITLE
Restructure header into two rows; revert primary color to navy

### DIFF
--- a/build_dashboard.py
+++ b/build_dashboard.py
@@ -318,11 +318,11 @@ def main() -> None:
   /* Semantic aliases */
   --bg: var(--nanda-white);
   --surface: var(--nanda-white);
-  --text: var(--nanda-blue-dark);
+  --text: #1a1a1a;
   --muted: #555555;
   --accent: var(--nanda-blue-light);
   --border: #d0d7de;
-  --pos: #1a7f37;
+  --pos: #166534;
   --neg: #b42318;
   --row-hover: #eaf4fb;
   --focus: #ff8a00;
@@ -366,27 +366,36 @@ a:focus-visible, button:focus-visible, input:focus-visible, summary:focus-visibl
 
 header {{
   display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  margin-bottom: 2rem;
+}}
+.header-title h1 {{
+  margin: 0;
+  font-size: clamp(1.4rem, 2.5vw, 1.8rem);
+  line-height: 1.2;
+  color: var(--text);
+}}
+.header-title .tagline {{
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+  max-width: 65ch;
+}}
+.header-meta {{
+  display: flex;
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 1rem;
-  margin-bottom: 1.75rem;
+  gap: 0.75rem 1.5rem;
 }}
-.brand {{
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  flex-wrap: wrap;
-}}
-.brand .logo {{
+.header-meta .logo {{
   height: 44px;
   width: auto;
   display: block;
 }}
-.brand h1 {{ margin: 0; font-size: clamp(1.4rem, 2.5vw, 1.8rem); line-height: 1.2; color: var(--nanda-blue-dark); }}
-.tagline {{ margin: 0.25rem 0 0; color: var(--muted); font-size: 0.95rem; max-width: 60ch; }}
 .updated {{ margin: 0; color: var(--muted); font-size: 0.9rem; }}
-.updated time {{ font-weight: 700; color: var(--nanda-blue-dark); }}
+.updated time {{ font-weight: 700; color: var(--text); }}
 
 section {{
   background: var(--surface);
@@ -398,7 +407,7 @@ section {{
 section h2 {{
   margin: 0 0 1rem;
   font-size: 1.15rem;
-  color: var(--nanda-blue-dark);
+  color: var(--text);
   font-weight: 700;
 }}
 section .definition {{
@@ -410,7 +419,7 @@ section .definition {{
   font-size: 0.92rem;
   color: var(--text);
 }}
-.definition strong {{ color: var(--nanda-blue-dark); font-weight: 700; }}
+.definition strong {{ color: var(--text); font-weight: 700; }}
 
 /* KPI cards */
 .kpis {{
@@ -439,7 +448,7 @@ section .definition {{
   margin: 0.35rem 0 0;
   font-size: 2rem;
   font-weight: 700;
-  color: var(--nanda-blue-dark);
+  color: var(--text);
   font-variant-numeric: tabular-nums;
   line-height: 1.1;
 }}
@@ -472,7 +481,7 @@ section .definition {{
 .filter-row label {{
   font-weight: 700;
   font-size: 0.95rem;
-  color: var(--nanda-blue-dark);
+  color: var(--text);
 }}
 .filter-row input[type="search"] {{
   flex: 1 1 220px;
@@ -513,10 +522,10 @@ table.studies-table tbody td {{
   color: var(--text);
 }}
 table.studies-table th {{
-  background: #eef4fa;
+  background: #f0f3f6;
   font-size: 0.875rem;
   font-weight: 700;
-  color: var(--nanda-blue-dark);
+  color: var(--text);
 }}
 table.studies-table th.num,
 table.studies-table td.num {{
@@ -560,8 +569,8 @@ table.studies-table th.num button.sort-btn {{
   justify-content: flex-end;
 }}
 button.sort-btn:hover {{ text-decoration: underline; text-underline-offset: 3px; }}
-th[aria-sort="ascending"] button.sort-btn::after {{ content: "▲"; font-size: 0.75em; color: var(--accent); }}
-th[aria-sort="descending"] button.sort-btn::after {{ content: "▼"; font-size: 0.75em; color: var(--accent); }}
+th[aria-sort="ascending"] button.sort-btn::after {{ content: "▲"; font-size: 0.75em; color: var(--nanda-blue-dark); }}
+th[aria-sort="descending"] button.sort-btn::after {{ content: "▼"; font-size: 0.75em; color: var(--nanda-blue-dark); }}
 th[aria-sort="none"] button.sort-btn::after {{ content: "↕"; font-size: 0.8em; color: var(--muted); opacity: 0.6; }}
 
 .row-hidden {{ display: none; }}
@@ -581,7 +590,7 @@ details {{
 details > summary {{
   cursor: pointer;
   font-weight: 700;
-  color: var(--nanda-blue-dark);
+  color: var(--text);
 }}
 details[open] > summary {{ margin-bottom: 0.5rem; }}
 details p {{ margin: 0.5rem 0 0; }}
@@ -605,8 +614,8 @@ footer nav a {{ font-weight: 700; }}
 footer p {{ margin: 0; }}
 
 @media (max-width: 600px) {{
-  header {{ flex-direction: column; align-items: flex-start; }}
-  .brand .logo {{ height: 36px; }}
+  header {{ gap: 1.25rem; }}
+  .header-meta {{ gap: 0.5rem 1rem; }}
   .kpi {{ padding: 1rem 1.1rem; }}
   .kpi-value {{ font-size: 1.6rem; }}
   section {{ padding: 1.1rem; }}
@@ -620,14 +629,14 @@ footer p {{ margin: 0; }}
 <a class="skip-link" href="#main">Skip to main content</a>
 <div class="page">
 <header>
-  <div class="brand">
-    <img src="assets/nanda-logo.svg" alt="National Neighborhood Data Archive logo" class="logo" width="220" height="38">
-    <div>
-      <h1>NaNDA Usage Dashboard</h1>
-      <p class="tagline">The National Neighborhood Data Archive — monthly usage of our datasets on ICPSR and openICPSR.</p>
-    </div>
+  <div class="header-title">
+    <h1>NaNDA Usage Dashboard</h1>
+    <p class="tagline">The National Neighborhood Data Archive — monthly usage of our datasets on ICPSR and openICPSR.</p>
   </div>
-  <p class="updated">Last updated <time datetime="{today_iso}">{today_human}</time></p>
+  <div class="header-meta">
+    <img src="assets/nanda-logo.svg" alt="National Neighborhood Data Archive logo" class="logo" width="220" height="38">
+    <p class="updated">Last updated <time datetime="{today_iso}">{today_human}</time></p>
+  </div>
 </header>
 
 <main id="main">
@@ -779,7 +788,8 @@ new Chart(document.getElementById("ts-chart"), {{
       fill: true,
       tension: 0.25,
       pointRadius: 2,
-      pointBackgroundColor: "#01528a",
+      pointBackgroundColor: "#1499d6",
+      pointBorderColor: "#1499d6",
     }}],
   }},
   options: {{
@@ -796,13 +806,13 @@ new Chart(document.getElementById("ts-chart"), {{
     scales: {{
       y: {{
         beginAtZero: true,
-        ticks: {{ callback: v => v.toLocaleString(), color: "#01528a" }},
-        title: {{ display: true, text: "Downloads per month", color: "#01528a", font: {{ size: 13, weight: "700" }} }},
-        grid: {{ color: "rgba(1, 82, 138, 0.08)" }},
+        ticks: {{ callback: v => v.toLocaleString(), color: "#1a1a1a" }},
+        title: {{ display: true, text: "Downloads per month", color: "#1a1a1a", font: {{ size: 13, weight: "700" }} }},
+        grid: {{ color: "rgba(26, 26, 26, 0.08)" }},
       }},
       x: {{
-        ticks: {{ maxRotation: 45, autoSkip: true, maxTicksLimit: 16, color: "#01528a" }},
-        grid: {{ color: "rgba(1, 82, 138, 0.08)" }},
+        ticks: {{ maxRotation: 45, autoSkip: true, maxTicksLimit: 16, color: "#1a1a1a" }},
+        grid: {{ color: "rgba(26, 26, 26, 0.08)" }},
       }},
     }},
   }},

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,11 +17,11 @@
   /* Semantic aliases */
   --bg: var(--nanda-white);
   --surface: var(--nanda-white);
-  --text: var(--nanda-blue-dark);
+  --text: #1a1a1a;
   --muted: #555555;
   --accent: var(--nanda-blue-light);
   --border: #d0d7de;
-  --pos: #1a7f37;
+  --pos: #166534;
   --neg: #b42318;
   --row-hover: #eaf4fb;
   --focus: #ff8a00;
@@ -65,27 +65,36 @@ a:focus-visible, button:focus-visible, input:focus-visible, summary:focus-visibl
 
 header {
   display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  margin-bottom: 2rem;
+}
+.header-title h1 {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.5vw, 1.8rem);
+  line-height: 1.2;
+  color: var(--text);
+}
+.header-title .tagline {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+  max-width: 65ch;
+}
+.header-meta {
+  display: flex;
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 1rem;
-  margin-bottom: 1.75rem;
+  gap: 0.75rem 1.5rem;
 }
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-.brand .logo {
+.header-meta .logo {
   height: 44px;
   width: auto;
   display: block;
 }
-.brand h1 { margin: 0; font-size: clamp(1.4rem, 2.5vw, 1.8rem); line-height: 1.2; color: var(--nanda-blue-dark); }
-.tagline { margin: 0.25rem 0 0; color: var(--muted); font-size: 0.95rem; max-width: 60ch; }
 .updated { margin: 0; color: var(--muted); font-size: 0.9rem; }
-.updated time { font-weight: 700; color: var(--nanda-blue-dark); }
+.updated time { font-weight: 700; color: var(--text); }
 
 section {
   background: var(--surface);
@@ -97,7 +106,7 @@ section {
 section h2 {
   margin: 0 0 1rem;
   font-size: 1.15rem;
-  color: var(--nanda-blue-dark);
+  color: var(--text);
   font-weight: 700;
 }
 section .definition {
@@ -109,7 +118,7 @@ section .definition {
   font-size: 0.92rem;
   color: var(--text);
 }
-.definition strong { color: var(--nanda-blue-dark); font-weight: 700; }
+.definition strong { color: var(--text); font-weight: 700; }
 
 /* KPI cards */
 .kpis {
@@ -138,7 +147,7 @@ section .definition {
   margin: 0.35rem 0 0;
   font-size: 2rem;
   font-weight: 700;
-  color: var(--nanda-blue-dark);
+  color: var(--text);
   font-variant-numeric: tabular-nums;
   line-height: 1.1;
 }
@@ -171,7 +180,7 @@ section .definition {
 .filter-row label {
   font-weight: 700;
   font-size: 0.95rem;
-  color: var(--nanda-blue-dark);
+  color: var(--text);
 }
 .filter-row input[type="search"] {
   flex: 1 1 220px;
@@ -212,10 +221,10 @@ table.studies-table tbody td {
   color: var(--text);
 }
 table.studies-table th {
-  background: #eef4fa;
+  background: #f0f3f6;
   font-size: 0.875rem;
   font-weight: 700;
-  color: var(--nanda-blue-dark);
+  color: var(--text);
 }
 table.studies-table th.num,
 table.studies-table td.num {
@@ -259,8 +268,8 @@ table.studies-table th.num button.sort-btn {
   justify-content: flex-end;
 }
 button.sort-btn:hover { text-decoration: underline; text-underline-offset: 3px; }
-th[aria-sort="ascending"] button.sort-btn::after { content: "▲"; font-size: 0.75em; color: var(--accent); }
-th[aria-sort="descending"] button.sort-btn::after { content: "▼"; font-size: 0.75em; color: var(--accent); }
+th[aria-sort="ascending"] button.sort-btn::after { content: "▲"; font-size: 0.75em; color: var(--nanda-blue-dark); }
+th[aria-sort="descending"] button.sort-btn::after { content: "▼"; font-size: 0.75em; color: var(--nanda-blue-dark); }
 th[aria-sort="none"] button.sort-btn::after { content: "↕"; font-size: 0.8em; color: var(--muted); opacity: 0.6; }
 
 .row-hidden { display: none; }
@@ -280,7 +289,7 @@ details {
 details > summary {
   cursor: pointer;
   font-weight: 700;
-  color: var(--nanda-blue-dark);
+  color: var(--text);
 }
 details[open] > summary { margin-bottom: 0.5rem; }
 details p { margin: 0.5rem 0 0; }
@@ -304,8 +313,8 @@ footer nav a { font-weight: 700; }
 footer p { margin: 0; }
 
 @media (max-width: 600px) {
-  header { flex-direction: column; align-items: flex-start; }
-  .brand .logo { height: 36px; }
+  header { gap: 1.25rem; }
+  .header-meta { gap: 0.5rem 1rem; }
   .kpi { padding: 1rem 1.1rem; }
   .kpi-value { font-size: 1.6rem; }
   section { padding: 1.1rem; }
@@ -319,14 +328,14 @@ footer p { margin: 0; }
 <a class="skip-link" href="#main">Skip to main content</a>
 <div class="page">
 <header>
-  <div class="brand">
-    <img src="assets/nanda-logo.svg" alt="National Neighborhood Data Archive logo" class="logo" width="220" height="38">
-    <div>
-      <h1>NaNDA Usage Dashboard</h1>
-      <p class="tagline">The National Neighborhood Data Archive — monthly usage of our datasets on ICPSR and openICPSR.</p>
-    </div>
+  <div class="header-title">
+    <h1>NaNDA Usage Dashboard</h1>
+    <p class="tagline">The National Neighborhood Data Archive — monthly usage of our datasets on ICPSR and openICPSR.</p>
   </div>
-  <p class="updated">Last updated <time datetime="2026-05-01">May 1, 2026</time></p>
+  <div class="header-meta">
+    <img src="assets/nanda-logo.svg" alt="National Neighborhood Data Archive logo" class="logo" width="220" height="38">
+    <p class="updated">Last updated <time datetime="2026-05-01">May 1, 2026</time></p>
+  </div>
 </header>
 
 <main id="main">
@@ -623,7 +632,8 @@ new Chart(document.getElementById("ts-chart"), {
       fill: true,
       tension: 0.25,
       pointRadius: 2,
-      pointBackgroundColor: "#01528a",
+      pointBackgroundColor: "#1499d6",
+      pointBorderColor: "#1499d6",
     }],
   },
   options: {
@@ -640,13 +650,13 @@ new Chart(document.getElementById("ts-chart"), {
     scales: {
       y: {
         beginAtZero: true,
-        ticks: { callback: v => v.toLocaleString(), color: "#01528a" },
-        title: { display: true, text: "Downloads per month", color: "#01528a", font: { size: 13, weight: "700" } },
-        grid: { color: "rgba(1, 82, 138, 0.08)" },
+        ticks: { callback: v => v.toLocaleString(), color: "#1a1a1a" },
+        title: { display: true, text: "Downloads per month", color: "#1a1a1a", font: { size: 13, weight: "700" } },
+        grid: { color: "rgba(26, 26, 26, 0.08)" },
       },
       x: {
-        ticks: { maxRotation: 45, autoSkip: true, maxTicksLimit: 16, color: "#01528a" },
-        grid: { color: "rgba(1, 82, 138, 0.08)" },
+        ticks: { maxRotation: 45, autoSkip: true, maxTicksLimit: 16, color: "#1a1a1a" },
+        grid: { color: "rgba(26, 26, 26, 0.08)" },
       },
     },
   },


### PR DESCRIPTION
Header layout
- Row 1: title + subtitle, full width — becomes the visual anchor
- Row 2: logo (left) + "Last updated" (right), vertically centered
- Logo restored to its full 44px height; gets its own visual moment
- Mobile: logo and date wrap if both don't fit, logo first then date below
- 1.75rem gap between rows for breathing room

Color revert
- Primary color (--text) reverts to #1a1a1a — the value used before the NaNDA color refactor. Headings, body text, KPI numbers, table headers, table cells, definition strong, summary text all return to this dark tone.
- Hyperlinks stay --nanda-blue-dark (#01528a) — brand still shows up on links per spec.
- Chart line and data points stay --nanda-blue-light (#1499d6); chart axis text, ticks, gridlines revert to navy (#1a1a1a).
- Sort indicator arrow reverts to --nanda-blue-dark (matches the pre-refactor look where it was --brand).
- KPI deltas: positive nudged from #1a7f37 to #166534 (green-800). The previous green technically cleared 4.5:1 on the row-hover blue tint (4.55:1) but with no margin; the darker green is 7.13:1 on white and 6.39:1 on row-hover.

Verification
- axe-core: 0 violations, 53 passes, 1 incomplete (unmeasurable contrast on a sort button — not a real failure)
- Manual contrast (in-page): h1 17.40:1, body 17.40:1, KPI value 17.40:1, table cell 17.40:1, table th 15.63:1, tagline 7.46:1, KPI delta-pos 7.13:1, footer link 8.15:1
- Title leads visually — first content under <main>'s ancestor
- No horizontal page scroll at 1280px or 375px
- Logo alt text preserved: "National Neighborhood Data Archive logo"