### PR TITLE
Add add_to_inventory.py helper for safe inventory appends

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,22 @@ Dataset titles are read from `inventory.csv` at startup, not fetched live. `clou
 
 ## Maintaining the inventory
 
-`inventory.csv` is the single file to edit when datasets are added or removed. Each row carries `study_id`, `archive` (`ICPSR` or `openICPSR`), `deposit_via` (`legacy` or `RDE`), `status` (`published` or `unpublished`), `title`, `version`, `version_date`, `doi`, and `url`. The scraper derives the list of studies to scrape from `study_id` at runtime, joins titles by ID, and routes API calls by `archive`. To add a dataset, append a row, commit, and push — the next monthly run picks it up automatically.
+`inventory.csv` is the single file to edit when datasets are added or removed. Each row carries `study_id`, `archive` (`ICPSR` or `openICPSR`), `deposit_via` (`legacy` or `RDE`), `status` (`published` or `unpublished`), `title`, `version`, `version_date`, `doi`, and `url`. The scraper derives the list of studies to scrape from `study_id` at runtime, joins titles by ID, and routes API calls by `archive`.
+
+To add a newly-published dataset, use the `add_to_inventory.py` helper. It fetches title, version, version_date, and DOI from DataCite (with a fallback to the public ICPSR page), validates the result, and appends a row. It never commits or pushes — it prints the git commands for you to run after eyeballing the row.
+
+```bash
+python add_to_inventory.py <study_id> --archive {ICPSR|openICPSR} [--deposit-via {legacy|RDE}] [--dry-run] [--force]
+```
+
+Example — add ICPSR 305511 (Parks and Proximity to Polluting Sites):
+
+```bash
+python add_to_inventory.py 305511 --archive ICPSR --dry-run    # preview
+python add_to_inventory.py 305511 --archive ICPSR              # write
+```
+
+Use `--dry-run` to see what would be written; `--force` to overwrite an existing row for the same `study_id` (useful for fixing a typo). Hand-editing `inventory.csv` still works for edge cases the validator rejects.
 
 ## Running locally
 

--- a/add_to_inventory.py
+++ b/add_to_inventory.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""
+add_to_inventory.py — safely append a new NaNDA dataset to inventory.csv.
+
+Usage:
+    python add_to_inventory.py <study_id> --archive {ICPSR|openICPSR}
+                              [--deposit-via {legacy|RDE}]
+                              [--dry-run] [--force]
+
+Fetches title / version / version_date / DOI from public ICPSR sources, runs
+strict validation gates, and appends a row to inventory.csv. Never commits
+or pushes — prints the git commands for the operator to run after eyeballing
+the row.
+
+Metadata sources (chosen by reliability):
+
+  1. DataCite REST API (api.datacite.org/dois/{doi}) — primary. ICPSR mints
+     DOIs at publication, so this is fresh on day-zero releases. Endpoint
+     returns title, version, `created` timestamp (matches inventory
+     version_date for both archives in spot-checks), and confirms the DOI
+     resolves. Free, no auth, returns structured JSON.
+
+  2. ICPSR public study page JSON-LD — fallback for curated ICPSR
+     (`https://www.icpsr.umich.edu/web/ICPSR/studies/{id}`). Inline
+     `<script type="application/ld+json">` carries name, version,
+     dateModified, and identifier.value (DOI).
+
+  3. openICPSR project page JSON-LD — fallback for openICPSR
+     (`https://www.openicpsr.org/openicpsr/project/{id}/view`). Same JSON-LD
+     shape, but only ever exposes the V1 metadata even when newer minor
+     versions exist; treat with care for late updates.
+
+The other endpoints considered and rejected:
+  - ICPSR search API (`search.icpsr.umich.edu/.../studies`) — already used
+    by the monthly scraper for publication counts but returns 0 results
+    for fresh study IDs; not useful at first-publication moment.
+  - The new ICPSR sites pages (`/sites/icpsr/view/studies/{id}`) are a
+    Next.js app with no useful HTML payload — content is hydrated
+    client-side. Skipped.
+
+Constraints:
+  - Append-only. Use --force to overwrite a duplicate study_id (typo fix).
+  - Status is always 'published' — this helper is only used post-release.
+  - HTTP failures → exit non-zero, write nothing.
+  - Validation gate failure → exit non-zero, write nothing.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import cloudscraper
+import pandas as pd
+import requests
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+INVENTORY_PATH = Path(__file__).parent / "inventory.csv"
+
+NANDA_PREFIX = "National Neighborhood Data Archive (NaNDA):"
+
+CSV_COLUMNS = [
+    "study_id", "archive", "deposit_via", "status", "title",
+    "version", "version_date", "doi", "url",
+]
+
+DATACITE_DOI_URL = "https://api.datacite.org/dois/{doi}"
+ICPSR_STUDY_URL = "https://www.icpsr.umich.edu/web/ICPSR/studies/{id}"
+OPENICPSR_PROJECT_URL = "https://www.openicpsr.org/openicpsr/project/{id}/view"
+LANDING_URL = "https://www.icpsr.umich.edu/sites/icpsr/view/studies/{id}"
+
+HTTP_TIMEOUT = 30
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def iso_to_slash_date(iso_date: str) -> str:
+    """'2024-10-14' (or '2024-10-14T14:03:22.000Z') → '10/14/2024'."""
+    if not iso_date:
+        return ""
+    m = re.match(r"^(\d{4})-(\d{1,2})-(\d{1,2})", iso_date)
+    if not m:
+        return iso_date
+    y, mo, d = m.group(1), str(int(m.group(2))), str(int(m.group(3)))
+    return f"{mo}/{d}/{y}"
+
+
+def construct_candidate_dois(study_id: int, archive: str) -> list:
+    """First-publication DOI guesses, ordered by likelihood."""
+    if archive == "ICPSR":
+        return [f"10.3886/ICPSR{study_id}.v1"]
+    # openICPSR: bare 'V1' is the first-deposit form; the 'V10' style appears
+    # only when a minor version exists. Try both.
+    return [f"10.3886/E{study_id}V1", f"10.3886/E{study_id}V10"]
+
+
+def fetch_datacite(doi: str) -> dict | None:
+    """Return DataCite attributes for `doi`, or None on 404."""
+    r = requests.get(
+        DATACITE_DOI_URL.format(doi=doi),
+        timeout=HTTP_TIMEOUT,
+        headers={"Accept": "application/vnd.api+json"},
+    )
+    if r.status_code == 404:
+        return None
+    r.raise_for_status()
+    return r.json().get("data", {}).get("attributes", {})
+
+
+def parse_datacite(attrs: dict, doi: str) -> dict:
+    """DataCite attributes → row dict (title, version, version_date, doi)."""
+    titles = attrs.get("titles") or []
+    title = titles[0].get("title", "") if titles else ""
+    version = attrs.get("version") or ""
+    # Normalize 'v1' → 'V1', '1.0' → 'V1.0'.
+    if version:
+        if version[0] in ("v", "V"):
+            version = "V" + version[1:]
+        else:
+            version = "V" + version
+    created = attrs.get("created") or ""
+    return {
+        "title": title,
+        "version": version,
+        "version_date": iso_to_slash_date(created),
+        "doi": doi,
+    }
+
+
+def fetch_json_ld(url: str) -> dict | None:
+    """Pull the first JSON-LD block from `url`; None if page is missing/empty."""
+    scraper = cloudscraper.create_scraper(
+        browser={"browser": "chrome", "platform": "windows", "mobile": False}
+    )
+    scraper.headers.update({
+        "Accept": "text/html,application/xhtml+xml",
+        "Accept-Language": "en-US,en;q=0.9",
+    })
+    r = scraper.get(url, timeout=HTTP_TIMEOUT, allow_redirects=True)
+    r.raise_for_status()
+    m = re.search(
+        r'<script type="application/ld\+json">\s*(\{.+?\})\s*</script>',
+        r.text, re.DOTALL,
+    )
+    if not m:
+        return None
+    try:
+        return json.loads(m.group(1))
+    except json.JSONDecodeError:
+        return None
+
+
+def parse_json_ld(ld: dict) -> dict:
+    """JSON-LD dict → row dict (title, version, version_date, doi)."""
+    title = ld.get("name", "")
+    version = ld.get("version", "") or ""
+    # ICPSR curated emits dateModified for version date; openICPSR omits it
+    # and only carries datePublished (which is the original deposit date).
+    date_iso = ld.get("dateModified") or ld.get("datePublished") or ""
+    ident = ld.get("identifier") or {}
+    raw_doi = ident.get("value", "") if isinstance(ident, dict) else ""
+    doi = raw_doi.removeprefix("doi:") if raw_doi else ""
+    return {
+        "title": title,
+        "version": version,
+        "version_date": iso_to_slash_date(date_iso),
+        "doi": doi,
+    }
+
+
+def fetch_metadata(study_id: int, archive: str) -> dict:
+    """Try DataCite first, then the archive's public page. Returns row dict
+    with title/version/version_date/doi. Raises on total failure.
+    """
+    errors = []
+
+    # 1. DataCite (primary).
+    for doi in construct_candidate_dois(study_id, archive):
+        try:
+            attrs = fetch_datacite(doi)
+        except requests.RequestException as e:
+            errors.append(f"datacite {doi}: {e}")
+            continue
+        if attrs:
+            return parse_datacite(attrs, doi)
+
+    # 2. Archive page JSON-LD (fallback).
+    page_url = (ICPSR_STUDY_URL if archive == "ICPSR" else OPENICPSR_PROJECT_URL)
+    page_url = page_url.format(id=study_id)
+    try:
+        ld = fetch_json_ld(page_url)
+    except requests.RequestException as e:
+        errors.append(f"page {page_url}: {e}")
+        ld = None
+
+    if ld:
+        out = parse_json_ld(ld)
+        if out["doi"]:
+            return out
+        errors.append(f"page {page_url}: JSON-LD has no DOI")
+    else:
+        errors.append(f"page {page_url}: no JSON-LD block")
+
+    raise RuntimeError("metadata fetch failed: " + "; ".join(errors))
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+VERSION_RE = re.compile(r"^V\d+(\.\d+)?$")
+DATE_RE = re.compile(r"^\d{1,2}/\d{1,2}/\d{4}$")
+URL_PREFIXES = ("https://www.icpsr.umich.edu/", "https://www.openicpsr.org/")
+TITLE_PREFIX = "National Neighborhood Data Archive (NaNDA):"
+
+
+def validate_row(row: dict) -> list:
+    """Return a list of validation-failure messages (empty if all pass)."""
+    errs = []
+    title = row.get("title") or ""
+    if not title.startswith(TITLE_PREFIX):
+        errs.append(f"title must start with {TITLE_PREFIX!r}; got {title[:80]!r}")
+    if row.get("archive") not in {"ICPSR", "openICPSR"}:
+        errs.append(f"archive must be 'ICPSR' or 'openICPSR'; got {row.get('archive')!r}")
+    if row.get("deposit_via") not in {"legacy", "RDE"}:
+        errs.append(f"deposit_via must be 'legacy' or 'RDE'; got {row.get('deposit_via')!r}")
+    if not VERSION_RE.match(row.get("version") or ""):
+        errs.append(f"version must match V<n>[.<m>]; got {row.get('version')!r}")
+    if not DATE_RE.match(row.get("version_date") or ""):
+        errs.append(f"version_date must match M/D/YYYY; got {row.get('version_date')!r}")
+    if not (row.get("doi") or "").startswith("10.3886/"):
+        errs.append(f"doi must start with '10.3886/'; got {row.get('doi')!r}")
+    url = row.get("url") or ""
+    if not any(url.startswith(p) for p in URL_PREFIXES):
+        errs.append(f"url must start with one of {URL_PREFIXES}; got {url!r}")
+    return errs
+
+
+# ---------------------------------------------------------------------------
+# Inventory I/O
+# ---------------------------------------------------------------------------
+
+def load_inventory(path: Path) -> pd.DataFrame:
+    return pd.read_csv(path, encoding="utf-8", dtype={"study_id": int})
+
+
+def write_inventory(df: pd.DataFrame, path: Path) -> None:
+    df.to_csv(path, index=False, encoding="utf-8")
+
+
+def build_row(study_id: int, archive: str, deposit_via: str, meta: dict) -> dict:
+    return {
+        "study_id": study_id,
+        "archive": archive,
+        "deposit_via": deposit_via,
+        "status": "published",
+        "title": meta["title"],
+        "version": meta["version"],
+        "version_date": meta["version_date"],
+        "doi": meta["doi"],
+        "url": LANDING_URL.format(id=study_id),
+    }
+
+
+def format_row_preview(row: dict) -> str:
+    width = max(len(k) for k in row)
+    return "\n".join(f"  {k:<{width}}  {row[k]}" for k in CSV_COLUMNS)
+
+
+def title_snippet(title: str, max_len: int = 60) -> str:
+    body = title.removeprefix(TITLE_PREFIX).strip(" :")
+    if len(body) > max_len:
+        body = body[: max_len - 3].rstrip() + "..."
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[1],
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("study_id", type=int, help="ICPSR or openICPSR study/project ID")
+    p.add_argument("--archive", required=True, choices=["ICPSR", "openICPSR"],
+                   help="Which archive the dataset lives in")
+    p.add_argument("--deposit-via", default="legacy", choices=["legacy", "RDE"],
+                   help="Deposit pathway (default: legacy)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Fetch and print the row; do not modify inventory.csv")
+    p.add_argument("--force", action="store_true",
+                   help="Replace an existing row for the same study_id")
+    return p.parse_args(argv)
+
+
+def run(args: argparse.Namespace) -> int:
+    inv_path = INVENTORY_PATH
+    df = load_inventory(inv_path)
+    existing_idx = df.index[df["study_id"] == args.study_id].tolist()
+
+    if existing_idx and not args.force and not args.dry_run:
+        existing = df.loc[existing_idx[0]].to_dict()
+        print(f"ERROR: study_id {args.study_id} already in inventory.csv. "
+              f"Re-run with --force to overwrite.", file=sys.stderr)
+        print("Existing row:", file=sys.stderr)
+        print(format_row_preview(existing), file=sys.stderr)
+        return 2
+
+    try:
+        meta = fetch_metadata(args.study_id, args.archive)
+    except (requests.RequestException, RuntimeError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 3
+
+    row = build_row(args.study_id, args.archive, args.deposit_via, meta)
+    errs = validate_row(row)
+    if errs:
+        print("ERROR: validation failed:", file=sys.stderr)
+        for msg in errs:
+            print(f"  - {msg}", file=sys.stderr)
+        print("Fetched row:", file=sys.stderr)
+        print(format_row_preview(row), file=sys.stderr)
+        print("\nHand-edit inventory.csv if the source metadata is correct "
+              "but doesn't match the validators.", file=sys.stderr)
+        return 4
+
+    print("Row to add:")
+    print(format_row_preview(row))
+
+    if args.dry_run:
+        print("\n[dry-run] inventory.csv was not modified.")
+        return 0
+
+    new_df = pd.DataFrame([row], columns=CSV_COLUMNS)
+    if existing_idx:
+        df.loc[existing_idx[0]] = new_df.iloc[0]
+        out_df = df
+        action = "replaced"
+    else:
+        out_df = pd.concat([df, new_df], ignore_index=True)
+        action = "appended"
+
+    write_inventory(out_df, inv_path)
+
+    # Sanity-check round-trip.
+    check_df = load_inventory(inv_path)
+    if len(check_df) != len(out_df):
+        print("ERROR: inventory.csv re-read row count mismatch "
+              f"(wrote {len(out_df)}, read {len(check_df)})", file=sys.stderr)
+        return 5
+    if (check_df["study_id"] == args.study_id).sum() != 1:
+        print(f"ERROR: study_id {args.study_id} appears "
+              f"{(check_df['study_id'] == args.study_id).sum()} times after write",
+              file=sys.stderr)
+        return 5
+
+    snippet = title_snippet(row["title"])
+    print(f"\n{action.title()} row in {inv_path.name}.")
+    print("\nNext steps:")
+    print("  cd usage-metrics")
+    print("  git add inventory.csv")
+    print(f"  git commit -m \"Add {snippet} ({args.study_id}) to inventory\"")
+    print("  git push")
+    return 0
+
+
+def main() -> int:
+    return run(parse_args())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_add_to_inventory.py
+++ b/tests/test_add_to_inventory.py
@@ -1,0 +1,243 @@
+"""Tests for add_to_inventory.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import add_to_inventory as ati  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+# Study IDs reserved for tests — never appear in the real inventory.csv.
+TEST_NEW_IDS = {999900, 999001, 888777}
+# A study that DOES exist in the real inventory; we copy that row into the
+# fixture to exercise duplicate-handling code.
+EXISTING_ID = 38506
+
+
+@pytest.fixture
+def temp_inventory(tmp_path, monkeypatch):
+    """Copy of inventory.csv in a temp dir, stripped of any test IDs."""
+    src = REPO_ROOT / "inventory.csv"
+    df = pd.read_csv(src, dtype={"study_id": int})
+    df = df[~df["study_id"].isin(TEST_NEW_IDS)].reset_index(drop=True)
+    dst = tmp_path / "inventory.csv"
+    df.to_csv(dst, index=False)
+    monkeypatch.setattr(ati, "INVENTORY_PATH", dst)
+    return dst
+
+
+def make_datacite_attrs(title: str, version: str = "v1",
+                       created: str = "2026-05-12T18:27:39.000Z") -> dict:
+    return {
+        "titles": [{"title": title}],
+        "version": version,
+        "created": created,
+    }
+
+
+PARKS_ATTRS = make_datacite_attrs(
+    "National Neighborhood Data Archive (NaNDA): Parks and Proximity to "
+    "Polluting Sites by Census Tract and ZIP Code Tabulation Area (ZCTA), "
+    "United States, 2024",
+)
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+def test_happy_path_icpsr_appends_row(temp_inventory):
+    before = pd.read_csv(temp_inventory)
+    args = ati.parse_args(["999900", "--archive", "ICPSR"])
+    parks_for_test = make_datacite_attrs(
+        PARKS_ATTRS["titles"][0]["title"],
+        version="V1",
+    )
+    with patch.object(ati, "fetch_datacite", return_value=parks_for_test):
+        rc = ati.run(args)
+    assert rc == 0
+    after = pd.read_csv(temp_inventory)
+    assert len(after) == len(before) + 1
+    new_row = after.iloc[-1]
+    assert new_row["study_id"] == 999900
+    assert new_row["archive"] == "ICPSR"
+    assert new_row["deposit_via"] == "legacy"
+    assert new_row["status"] == "published"
+    assert new_row["title"].startswith(ati.TITLE_PREFIX)
+    assert new_row["version"] == "V1"
+    assert new_row["version_date"] == "5/12/2026"
+    assert new_row["doi"] == "10.3886/ICPSR999900.v1"
+    assert new_row["url"].startswith("https://www.icpsr.umich.edu/")
+
+
+def test_happy_path_openicpsr_appends_row(temp_inventory):
+    before = pd.read_csv(temp_inventory)
+    attrs = make_datacite_attrs(
+        "National Neighborhood Data Archive (NaNDA): Test Dataset, United States, 2026",
+        version="V1.0",
+        created="2026-03-15T10:00:00.000Z",
+    )
+    args = ati.parse_args(["999001", "--archive", "openICPSR"])
+    # First DOI candidate (E999001V1) hits; no further DataCite calls expected.
+    with patch.object(ati, "fetch_datacite", return_value=attrs) as mock_dc:
+        rc = ati.run(args)
+    assert rc == 0
+    mock_dc.assert_called_once_with("10.3886/E999001V1")
+    after = pd.read_csv(temp_inventory)
+    assert len(after) == len(before) + 1
+    new_row = after.iloc[-1]
+    assert new_row["study_id"] == 999001
+    assert new_row["archive"] == "openICPSR"
+    assert new_row["version"] == "V1.0"
+    assert new_row["version_date"] == "3/15/2026"
+    assert new_row["doi"] == "10.3886/E999001V1"
+
+
+# ---------------------------------------------------------------------------
+# Duplicate handling
+# ---------------------------------------------------------------------------
+
+def test_duplicate_without_force_errors_and_leaves_csv(temp_inventory):
+    # 38506 is already in the inventory.
+    before = temp_inventory.read_bytes()
+    args = ati.parse_args(["38506", "--archive", "ICPSR"])
+    with patch.object(ati, "fetch_datacite", return_value=PARKS_ATTRS):
+        rc = ati.run(args)
+    assert rc == 2
+    assert temp_inventory.read_bytes() == before
+
+
+def test_duplicate_with_force_replaces_row(temp_inventory):
+    before = pd.read_csv(temp_inventory)
+    n_before = len(before)
+    attrs = make_datacite_attrs(
+        "National Neighborhood Data Archive (NaNDA): Voter Registration, "
+        "Turnout, and Partisanship by County, United States, 2004-2024",
+        version="V3",
+        created="2026-05-12T00:00:00.000Z",
+    )
+    args = ati.parse_args(["38506", "--archive", "ICPSR", "--force"])
+    with patch.object(ati, "fetch_datacite", return_value=attrs):
+        rc = ati.run(args)
+    assert rc == 0
+    after = pd.read_csv(temp_inventory)
+    assert len(after) == n_before
+    row = after.loc[after["study_id"] == 38506].iloc[0]
+    assert row["version"] == "V3"
+    assert row["version_date"] == "5/12/2026"
+
+
+# ---------------------------------------------------------------------------
+# Dry run
+# ---------------------------------------------------------------------------
+
+def test_dry_run_does_not_modify_csv(temp_inventory):
+    before = temp_inventory.read_bytes()
+    args = ati.parse_args(["999900", "--archive", "ICPSR", "--dry-run"])
+    with patch.object(ati, "fetch_datacite", return_value=PARKS_ATTRS):
+        rc = ati.run(args)
+    assert rc == 0
+    assert temp_inventory.read_bytes() == before
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def test_validation_failure_bad_title(temp_inventory):
+    before = temp_inventory.read_bytes()
+    bad = make_datacite_attrs("Some other dataset that is not NaNDA")
+    args = ati.parse_args(["999900", "--archive", "ICPSR"])
+    with patch.object(ati, "fetch_datacite", return_value=bad):
+        rc = ati.run(args)
+    assert rc == 4
+    assert temp_inventory.read_bytes() == before
+
+
+def test_validation_failure_bad_version(temp_inventory):
+    before = temp_inventory.read_bytes()
+    bad = make_datacite_attrs(
+        "National Neighborhood Data Archive (NaNDA): Something",
+        version="draft",
+    )
+    args = ati.parse_args(["999900", "--archive", "ICPSR"])
+    with patch.object(ati, "fetch_datacite", return_value=bad):
+        rc = ati.run(args)
+    assert rc == 4
+    assert temp_inventory.read_bytes() == before
+
+
+# ---------------------------------------------------------------------------
+# HTTP failures
+# ---------------------------------------------------------------------------
+
+def test_http_failure_exits_non_zero_and_leaves_csv(temp_inventory):
+    before = temp_inventory.read_bytes()
+    args = ati.parse_args(["999900", "--archive", "ICPSR"])
+
+    def boom(_doi):
+        raise requests.ConnectionError("network down")
+
+    with patch.object(ati, "fetch_datacite", side_effect=boom), \
+         patch.object(ati, "fetch_json_ld", side_effect=requests.ConnectionError("page down")):
+        rc = ati.run(args)
+    assert rc == 3
+    assert temp_inventory.read_bytes() == before
+
+
+def test_falls_back_to_json_ld_when_datacite_404(temp_inventory):
+    before = pd.read_csv(temp_inventory)
+    title = ("National Neighborhood Data Archive (NaNDA): Some new dataset, "
+             "United States, 2026")
+    ld = {
+        "name": title,
+        "version": "V1",
+        "dateModified": "2026-05-12",
+        "identifier": {"value": "doi:10.3886/ICPSR888777.v1"},
+    }
+    args = ati.parse_args(["888777", "--archive", "ICPSR"])
+    with patch.object(ati, "fetch_datacite", return_value=None), \
+         patch.object(ati, "fetch_json_ld", return_value=ld):
+        rc = ati.run(args)
+    assert rc == 0
+    after = pd.read_csv(temp_inventory)
+    assert len(after) == len(before) + 1
+    new_row = after.iloc[-1]
+    assert new_row["doi"] == "10.3886/ICPSR888777.v1"
+    assert new_row["version"] == "V1"
+    assert new_row["version_date"] == "5/12/2026"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def test_iso_to_slash_date():
+    assert ati.iso_to_slash_date("2024-10-14") == "10/14/2024"
+    assert ati.iso_to_slash_date("2026-05-12T18:27:39.000Z") == "5/12/2026"
+    assert ati.iso_to_slash_date("") == ""
+
+
+def test_validate_row_accepts_clean_row():
+    row = {
+        "study_id": 305511, "archive": "ICPSR", "deposit_via": "legacy",
+        "status": "published",
+        "title": "National Neighborhood Data Archive (NaNDA): Foo",
+        "version": "V1", "version_date": "5/12/2026",
+        "doi": "10.3886/ICPSR305511.v1",
+        "url": "https://www.icpsr.umich.edu/sites/icpsr/view/studies/305511",
+    }
+    assert ati.validate_row(row) == []


### PR DESCRIPTION
## Summary

- Adds `add_to_inventory.py` — a CLI helper that fetches title/version/version_date/DOI from DataCite (with a JSON-LD fallback to the public ICPSR page), validates the result, and appends one row to `inventory.csv`. Never commits or pushes; prints the git commands for the operator.
- Adds `tests/test_add_to_inventory.py` — 11 pytest cases with mocked HTTP covering happy paths for both archives, duplicate detection, `--force`, `--dry-run`, validation failures, and HTTP errors.
- Updates the "Maintaining the inventory" section of `README.md` to point at the helper.

## Why DataCite?

ICPSR mints DOIs at publication, so DataCite returns full metadata on day-zero releases — verified against study 305511 (Parks 2024, published 2026-05-12). The public ICPSR study page returned "Study Error" for 305511 today (likely Next.js caching lag), so the script keeps that page as a JSON-LD fallback rather than the primary. The ICPSR search API was rejected because it returns 0 results for fresh study IDs.

## Validation gates (refuses to write if any fail)

- Title begins with `National Neighborhood Data Archive (NaNDA):`
- `archive` in `{ICPSR, openICPSR}`
- `deposit_via` in `{legacy, RDE}`
- `version` matches `^V\d+(\.\d+)?$`
- `version_date` matches `^\d{1,2}/\d{1,2}/\d{4}$`
- `doi` starts with `10.3886/`
- `url` starts with `https://www.icpsr.umich.edu/` or `https://www.openicpsr.org/`

On gate failure the script prints which gate failed and the fetched row, and exits non-zero. Hand-editing `inventory.csv` still works for edge cases.

## What's NOT in this PR

The Parks 2024 row (study 305511) — append it after this lands by running:

```
python add_to_inventory.py 305511 --archive ICPSR --dry-run    # preview
python add_to_inventory.py 305511 --archive ICPSR              # write
```

## Test plan

- [ ] `pytest tests/` — 11 cases pass locally
- [ ] `python add_to_inventory.py 305511 --archive ICPSR --dry-run` prints the row without touching `inventory.csv`
- [ ] `python add_to_inventory.py 305511 --archive ICPSR` appends the row; `pandas.read_csv` still parses
- [ ] Re-running the same command exits non-zero with a duplicate-detection error and leaves `inventory.csv` unchanged
- [ ] `python nanda_usage_scraper.py` runs end-to-end against the updated `inventory.csv` (no new errors; 305511 produces a usage line, possibly with zero counts on day zero)
